### PR TITLE
make number of inputs to VerifySignature a constant

### DIFF
--- a/circuits/circom/test/verifySignature_test.circom
+++ b/circuits/circom/test/verifySignature_test.circom
@@ -1,3 +1,3 @@
 include "../verify_signature.circom"
 
-component main = VerifySignature(7);
+component main = VerifySignature7();

--- a/circuits/circom/updateStateTree.circom
+++ b/circuits/circom/updateStateTree.circom
@@ -167,7 +167,7 @@ template PerformChecksBeforeUpdate(
     new_vote_options_tree_root <== new_vote_options_tree.root;
 
     // Verify signature against existing public key
-    component signature_verifier = VerifySignature(MESSAGE_WITHOUT_SIGNATURE_LENGTH);
+    component signature_verifier = VerifySignature7();
 
     signature_verifier.from_x <== state_tree_data_raw[STATE_TREE_PUBLIC_KEY_X_IDX]; // public key x
     signature_verifier.from_y <== state_tree_data_raw[STATE_TREE_PUBLIC_KEY_Y_IDX]; // public key y

--- a/circuits/circom/verify_signature.circom
+++ b/circuits/circom/verify_signature.circom
@@ -108,12 +108,15 @@ template EdDSAMiMCSpongeVerifier_patched() {
 }
 
 
-template VerifySignature(k) {
+template VerifySignature7() {
+  // Verify the signature of a Command, which has exactly 7 elements in the preimage
   signal input from_x;
   signal input from_y;
   signal input R8x;
   signal input R8y;
   signal input S;
+
+  var k = 7;
   signal private input preimage[k];
 
   signal output valid;


### PR DESCRIPTION
### What's wrong

Fix #99 

### How it is fixed

The number of inputs to VerifySignature is now a constant. 

## Notes

- No change to the number of constrains

```
circuits (master)*$ npx snarkjs info -c build/qvtCircuit.json 
# Wires: 22242
# Constraints: 22142
# Private Inputs: 104
# Public Inputs: 4
# Outputs: 1
circuits (master)*$ npx snarkjs info -c build/batchUstCircuit.json 
# Wires: 90229
# Constraints: 90232
# Private Inputs: 159
# Public Inputs: 19
# Outputs: 1

```


![](https://i.imgur.com/finjXlU.jpg)