### PR TITLE
On-chain tally verification

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -21,7 +21,9 @@
         "test-batchProcessMessageAndQuadVoteTally": "NODE_OPTIONS=--max-old-space-size=4096 jest batchProcessMessageAndQuadVoteTally.test.ts",
         "test-batchProcessMessageAndQuadVoteTally-debug": "NODE_OPTIONS=--max-old-space-size=4096 node --inspect-brk ./node_modules/.bin/jest batchProcessMessageAndQuadVoteTally.test.ts",
         "test-hasher": "jest Hasher.test.ts",
-        "test-hasher-debug": "node --inspect-brk ./node_modules/.bin/jest Hasher.test.ts"
+        "test-hasher-debug": "node --inspect-brk ./node_modules/.bin/jest Hasher.test.ts",
+        "test-verifyTally": "jest VerifyTally.test.ts",
+        "test-verifyTally-debug": "node --inspect-brk ./node_modules/.bin/jest VerifyTally.test.ts"
     },
     "_moduleAliases": {
         "@maci-contracts": "."

--- a/contracts/scripts/runTestsInCircleCi.sh
+++ b/contracts/scripts/runTestsInCircleCi.sh
@@ -8,5 +8,6 @@ sleep 3 &&
 NODE_OPTIONS=--max-old-space-size=4096 npx jest --force-exit batchProcessMessageAndQuadVoteTally.test.ts &&
 npx jest --force-exit SignUp.test.ts &&
 npx jest --force-exit Hasher.test.ts &&
+npx jest --force-exit VerifyTally.test.ts &&
 npx jest --force-exit IncrementalMerkleTree.test.ts &&
 npx jest --force-exit IncrementalQuinTree.test.ts

--- a/contracts/sol/MACI.sol
+++ b/contracts/sol/MACI.sol
@@ -11,9 +11,10 @@ import { InitialVoiceCreditProxy } from './initialVoiceCreditProxy/InitialVoiceC
 import { SnarkConstants } from './SnarkConstants.sol';
 import { ComputeRoot } from './ComputeRoot.sol';
 import { MACIParameters } from './MACIParameters.sol';
+import { VerifyTally } from './VerifyTally.sol';
 import { Ownable } from "@openzeppelin/contracts/ownership/Ownable.sol";
 
-contract MACI is Ownable, DomainObjs, ComputeRoot, MACIParameters {
+contract MACI is Ownable, DomainObjs, ComputeRoot, MACIParameters, VerifyTally {
 
     // A nothing-up-my-sleeve zero value
     // Should be equal to 5503045433092194285660061905880311622788666850989422096966288514930349325741
@@ -561,6 +562,24 @@ contract MACI is Ownable, DomainObjs, ComputeRoot, MACIParameters {
 
         // Increment the batch #
         currentQvtBatchNum ++;
+    }
+
+    function verifyTallyResult(
+        uint8 _depth,
+        uint256 _index,
+        uint256 _leaf,
+        uint256[][] memory _pathElements,
+        uint256 _salt
+    ) public view returns (bool) {
+        uint256 computedRoot = computeMerkleRootFromPath(
+            _depth,
+            _index,
+            _leaf,
+            _pathElements
+        );
+
+        uint256 computedCommitment = hashLeftRight(computedRoot, _salt);
+        return computedCommitment == currentResultsCommitment;
     }
 
     function calcEmptyVoteOptionTreeRoot(uint8 _levels) public pure returns (uint256) {

--- a/contracts/sol/VerifyTally.sol
+++ b/contracts/sol/VerifyTally.sol
@@ -1,0 +1,42 @@
+pragma experimental ABIEncoderV2;
+pragma solidity ^0.5.0;
+
+import { Hasher } from "./Hasher.sol";
+
+contract VerifyTally is Hasher {
+
+    uint8 internal constant LEAVES_PER_NODE = 5;
+
+    function computeMerkleRootFromPath(
+        uint8 _depth,
+        uint256 _index,
+        uint256 _leaf,
+        uint256[][] memory _pathElements
+    ) public pure returns (uint256) {
+        uint256 pos = _index % LEAVES_PER_NODE;
+        uint256 current = _leaf;
+        uint8 k;
+
+        uint256[] memory level = new uint256[](LEAVES_PER_NODE);
+
+        for (uint8 i = 0; i < _depth; i ++) {
+            for (uint8 j = 0; j < LEAVES_PER_NODE; j ++) {
+                if (j == pos) {
+                    level[j] = current;
+                } else {
+                    if (j > pos) {
+                        k = j - 1;
+                    } else {
+                        k = j;
+                    }
+                    level[j] = _pathElements[i][k];
+                }
+            }
+
+            pos /= LEAVES_PER_NODE;
+            current = hash5(level);
+        }
+
+        return current;
+    }
+}

--- a/contracts/ts/__tests__/VerifyTally.test.ts
+++ b/contracts/ts/__tests__/VerifyTally.test.ts
@@ -1,0 +1,81 @@
+require('module-alias/register')
+import { genTestAccounts } from '../accounts'
+import { config } from 'maci-config'
+import {
+    hashLeftRight,
+    genRandomSalt,
+    bigInt,
+    IncrementalQuinTree,
+} from 'maci-crypto'
+import { genTallyResultCommitment } from 'maci-core'
+
+import * as etherlime from 'etherlime-lib'
+
+const PoseidonT3 = require('@maci-contracts/compiled/PoseidonT3.json')
+const PoseidonT6 = require('@maci-contracts/compiled/PoseidonT6.json')
+const VerifyTallyAbi = require('@maci-contracts/compiled/VerifyTally.json')
+
+const accounts = genTestAccounts(1)
+let deployer
+let verifyTallyContract
+let PoseidonT3Contract, PoseidonT6Contract
+const DEPTH = 4
+
+describe('VerifyTally', () => {
+    beforeAll(async () => {
+        deployer = new etherlime.JSONRPCPrivateKeyDeployer(
+            accounts[0].privateKey,
+            config.get('chain.url'),
+            {
+                gasLimit: 8800000,
+            },
+        )
+
+        console.log('Deploying PoseidonT3Contract')
+        PoseidonT3Contract = await deployer.deploy(PoseidonT3, {})
+        PoseidonT6Contract = await deployer.deploy(PoseidonT6, {})
+
+        console.log('Deploying VerifyTally')
+        verifyTallyContract = await deployer.deploy(
+            VerifyTallyAbi,
+            {
+                PoseidonT3: PoseidonT3Contract.contractAddress,
+                PoseidonT6: PoseidonT6Contract.contractAddress
+            },
+        )
+
+    })
+
+    it('computeMerklePath() should generate the correct root', async () => {
+        const results = [
+            bigInt(10),
+            bigInt(20),
+            bigInt(30),
+            bigInt(40),
+            bigInt(50),
+        ]
+        const salt = bigInt(1)
+        const commitment = genTallyResultCommitment(results, salt, DEPTH)
+
+        const tree = new IncrementalQuinTree(DEPTH, bigInt(0))
+        for (const result of results) {
+            tree.insert(result)
+        }
+        const root = tree.root
+        const expectedTallyCommitment = hashLeftRight(root, salt)
+        expect(expectedTallyCommitment.toString()).toEqual(commitment.toString())
+
+        const index = 2
+        const proof = tree.genMerklePath(index)
+        expect(IncrementalQuinTree.verifyMerklePath(proof, tree.hashFunc)).toBeTruthy()
+
+        const computedRoot = await verifyTallyContract.computeMerkleRootFromPath(
+            DEPTH,
+            index,
+            results[index].toString(),
+            proof.pathElements.map((x) => x.map((y) => y.toString())),
+        )
+        expect(computedRoot.toString()).toEqual(root.toString())
+    })
+
+})


### PR DESCRIPTION
This PR introduces a new contract function `MACI.verifyTallyResult()` which any contract can call to prove that they know the value of a vote tally leaf, or a batch of vote tally leaves.

Refer to https://github.com/appliedzkp/maci/issues/108 and https://github.com/appliedzkp/maci/issues/91 for more information.

The gist of it is that this function accepts a Merkle proof and the vote tally salt, recomputes the result commitment, and checks whether it matches the result commitment stored on-chain.

To prove that one knows the value of a batch of vote tally leaves, do the same but the Merkle proof should be a path to the intermediate node. e.g. I can prove that I know leaves 5-9 using a Merkle proof to intermediate node 1.

See the new unit tests in `batchProcessMessageAndQuadVoteTally.test.ts` to see how this is done.