### PR TITLE
Move PubKey and Message structs to MACISharedObjs contract

### DIFF
--- a/contracts/sol/DomainObjs.sol
+++ b/contracts/sol/DomainObjs.sol
@@ -2,15 +2,9 @@ pragma experimental ABIEncoderV2;
 pragma solidity ^0.5.0;
 
 import { Hasher } from "./Hasher.sol";
-import { MACIPubKey } from "./MACIPubKey.sol";
+import { MACISharedObjs } from "./MACISharedObjs.sol";
 
-contract DomainObjs is Hasher, MACIPubKey {
-    uint8 constant MESSAGE_DATA_LENGTH = 10;
-    struct Message {
-        uint256 iv;
-        uint256[MESSAGE_DATA_LENGTH] data;
-    }
-
+contract DomainObjs is Hasher, MACISharedObjs {
     struct StateLeaf {
         PubKey pubKey;
         uint256 voteOptionTreeRoot;

--- a/contracts/sol/MACIParameters.sol
+++ b/contracts/sol/MACIParameters.sol
@@ -1,9 +1,7 @@
 pragma experimental ABIEncoderV2;
 pragma solidity ^0.5.0;
 
-import { MACIPubKey } from "./MACIPubKey.sol";
-
-contract MACIParameters is MACIPubKey {
+contract MACIParameters {
     // This structs help to reduce the number of parameters to the constructor
     // and avoid a stack overflow error during compilation
     struct TreeDepths {

--- a/contracts/sol/MACIPubKey.sol
+++ b/contracts/sol/MACIPubKey.sol
@@ -1,9 +1,0 @@
-pragma experimental ABIEncoderV2;
-pragma solidity ^0.5.0;
-
-contract MACIPubKey {
-    struct PubKey {
-        uint256 x;
-        uint256 y;
-    }
-}

--- a/contracts/sol/MACISharedObjs.sol
+++ b/contracts/sol/MACISharedObjs.sol
@@ -1,0 +1,15 @@
+pragma experimental ABIEncoderV2;
+pragma solidity ^0.5.0;
+
+contract MACISharedObjs {
+    uint8 constant MESSAGE_DATA_LENGTH = 10;
+    struct Message {
+        uint256 iv;
+        uint256[MESSAGE_DATA_LENGTH] data;
+    }
+
+    struct PubKey {
+        uint256 x;
+        uint256 y;
+    }
+}


### PR DESCRIPTION
This is very similar to one of my previous PRs, #114. Our contract needs access to the `Message` struct, so I'm moving it along with `PubKey` to a new lightweight abstract contract called `MACISharedObjs`. (Maybe it was the initial purpose of `DomainObjs.sol` contract?)