### PR TITLE
Fixed incorrect Merkle proof verification logic in VerifyTally.computeMerkleRootFromPath

### DIFF
--- a/contracts/sol/VerifyTally.sol
+++ b/contracts/sol/VerifyTally.sol
@@ -33,7 +33,8 @@ contract VerifyTally is Hasher {
                 }
             }
 
-            pos /= LEAVES_PER_NODE;
+            _index /= LEAVES_PER_NODE;
+            pos = _index % LEAVES_PER_NODE;
             current = hash5(level);
         }
 


### PR DESCRIPTION
Thanks @NIC619 for spotting this bug!

This PR fixes the way the on-chain tally verification function computes the index per tree level.