### PR TITLE
Make it possible to decode event arguments of complex types

### DIFF
--- a/contracts/scripts/runTestsInCircleCi.sh
+++ b/contracts/scripts/runTestsInCircleCi.sh
@@ -7,6 +7,7 @@ npm run ganache &
 sleep 3 &&
 NODE_OPTIONS=--max-old-space-size=4096 npx jest --force-exit batchProcessMessageAndQuadVoteTally.test.ts &&
 npx jest --force-exit SignUp.test.ts &&
+npx jest --force-exit PublishMessage.test.ts &&
 npx jest --force-exit Hasher.test.ts &&
 npx jest --force-exit VerifyTally.test.ts &&
 npx jest --force-exit IncrementalMerkleTree.test.ts &&

--- a/contracts/sol/MACI.sol
+++ b/contracts/sol/MACI.sol
@@ -104,14 +104,16 @@ contract MACI is Ownable, DomainObjs, ComputeRoot, MACIParameters, VerifyTally {
 
     // Events
     event SignUp(
-        PubKey indexed _userPubKey,
-        uint256 indexed _stateIndex,
-        uint256 indexed _voiceCreditBalance
+        PubKey _userPubKey,
+        PubKey indexed _indexedUserPubKey,
+        uint256 _stateIndex,
+        uint256 _voiceCreditBalance
     );
 
     event PublishMessage(
-        Message indexed _message,
-        PubKey indexed _encPubKey
+        Message _message,
+        PubKey _encPubKey,
+        PubKey indexed _indexedEncPubKey
     );
 
     constructor(
@@ -289,7 +291,7 @@ contract MACI is Ownable, DomainObjs, ComputeRoot, MACIParameters, VerifyTally {
 
         // numSignUps is equal to the state index of the leaf which was just
         // added to the state tree above
-        emit SignUp(_userPubKey, numSignUps, voiceCreditBalance);
+        emit SignUp(_userPubKey, _userPubKey, numSignUps, voiceCreditBalance);
     }
 
     /*
@@ -335,7 +337,7 @@ contract MACI is Ownable, DomainObjs, ComputeRoot, MACIParameters, VerifyTally {
 
         numMessages ++;
 
-        emit PublishMessage(_message, _encPubKey);
+        emit PublishMessage(_message, _encPubKey, _encPubKey);
     }
 
     /*

--- a/contracts/sol/MACI.sol
+++ b/contracts/sol/MACI.sol
@@ -105,15 +105,13 @@ contract MACI is Ownable, DomainObjs, ComputeRoot, MACIParameters, VerifyTally {
     // Events
     event SignUp(
         PubKey _userPubKey,
-        PubKey indexed _indexedUserPubKey,
         uint256 _stateIndex,
         uint256 _voiceCreditBalance
     );
 
     event PublishMessage(
         Message _message,
-        PubKey _encPubKey,
-        PubKey indexed _indexedEncPubKey
+        PubKey _encPubKey
     );
 
     constructor(
@@ -291,7 +289,7 @@ contract MACI is Ownable, DomainObjs, ComputeRoot, MACIParameters, VerifyTally {
 
         // numSignUps is equal to the state index of the leaf which was just
         // added to the state tree above
-        emit SignUp(_userPubKey, _userPubKey, numSignUps, voiceCreditBalance);
+        emit SignUp(_userPubKey, numSignUps, voiceCreditBalance);
     }
 
     /*
@@ -337,7 +335,7 @@ contract MACI is Ownable, DomainObjs, ComputeRoot, MACIParameters, VerifyTally {
 
         numMessages ++;
 
-        emit PublishMessage(_message, _encPubKey, _encPubKey);
+        emit PublishMessage(_message, _encPubKey);
     }
 
     /*

--- a/contracts/ts/__tests__/PublishMessage.test.ts
+++ b/contracts/ts/__tests__/PublishMessage.test.ts
@@ -122,6 +122,10 @@ describe('Publishing messages', () => {
             )
             const receipt = await tx.wait()
             expect(receipt.status).toEqual(1)
+            const maciInterface = new ethers.utils.Interface(maciContract.interface.abi)
+            const event = maciInterface.parseLog(receipt.logs[1])
+            expect(event.values._message.data).toEqual(message.asContractParam()[1])
+            expect(event.values._encPubKey.x).toEqual(keypair.pubKey.asContractParam()[0])
 
             maciState.publishMessage(
                 message,

--- a/contracts/ts/__tests__/SignUp.test.ts
+++ b/contracts/ts/__tests__/SignUp.test.ts
@@ -208,7 +208,13 @@ describe('MACI', () => {
             expect(maciState.genStateRoot().toString()).toEqual(root.toString())
 
             const iface = new ethers.utils.Interface(maciContract.interface.abi)
-            const index = iface.parseLog(receipt.logs[1]).values._stateIndex
+            const event = iface.parseLog(receipt.logs[1])
+            const rawPubKey = [
+                bigInt(event.values._userPubKey[0]),
+                bigInt(event.values._userPubKey[1]),
+            ]
+            expect(rawPubKey).toEqual(user1.keypair.pubKey.rawPubKey)
+            const index = event.values._stateIndex
             expect(index.toString()).toEqual(maciState.users.length.toString())
         })
 


### PR DESCRIPTION
Changed `SignUp` and `PublishMessage` events to enable decoding of public keys and messages.

All arguments are now non-indexed, with the exception of `_indexedUserPubKey` and `_indexedEncPubKey` as it may be useful to filter events by user's public key. 

Resolves #146