### PR TITLE
Moved timeTravel import to individual test files

### DIFF
--- a/contracts/ts/__tests__/BatchProcessMessageAndQuadVoteTally.test.ts
+++ b/contracts/ts/__tests__/BatchProcessMessageAndQuadVoteTally.test.ts
@@ -5,7 +5,7 @@ jest.setTimeout(1200000)
 import * as ethers from 'ethers'
 
 import { genTestAccounts } from '../accounts'
-import { timeTravel } from '../'
+import { timeTravel } from '../../node_modules/etherlime/cli-commands/etherlime-test/time-travel.js'
 import { deployTestContracts } from '../utils'
 
 import { config } from 'maci-config'

--- a/contracts/ts/__tests__/PublishMessage.test.ts
+++ b/contracts/ts/__tests__/PublishMessage.test.ts
@@ -16,8 +16,8 @@ import {
     Keypair,
 } from 'maci-domainobjs'
 
+import { timeTravel } from '../../node_modules/etherlime/cli-commands/etherlime-test/time-travel.js'
 import {
-    timeTravel,
     genDeployer,
     genTestAccounts,
     deployMaci,

--- a/contracts/ts/__tests__/SignUp.test.ts
+++ b/contracts/ts/__tests__/SignUp.test.ts
@@ -5,7 +5,7 @@ jest.setTimeout(50000)
 import * as ethers from 'ethers'
 
 import { genTestAccounts } from '../accounts'
-import { timeTravel } from '../'
+import { timeTravel } from '../../node_modules/etherlime/cli-commands/etherlime-test/time-travel.js'
 
 import { config } from 'maci-config'
 

--- a/contracts/ts/index.ts
+++ b/contracts/ts/index.ts
@@ -14,10 +14,7 @@ import { formatProofForVerifierContract } from './utils'
 
 import { genAccounts, genTestAccounts } from './accounts'
 
-import { timeTravel } from '../node_modules/etherlime/cli-commands/etherlime-test/time-travel.js'
-
 export {
-    timeTravel,
     genDeployer,
     genJsonRpcDeployer,
     genAccounts,


### PR DESCRIPTION
This prevents a downstream error with importing `timeTravel` from Etherlime.