### PR TITLE
Don't inherit from Ownable

### DIFF
--- a/contracts/sol/MACI.sol
+++ b/contracts/sol/MACI.sol
@@ -12,9 +12,8 @@ import { SnarkConstants } from './SnarkConstants.sol';
 import { ComputeRoot } from './ComputeRoot.sol';
 import { MACIParameters } from './MACIParameters.sol';
 import { VerifyTally } from './VerifyTally.sol';
-import { Ownable } from "@openzeppelin/contracts/ownership/Ownable.sol";
 
-contract MACI is Ownable, DomainObjs, ComputeRoot, MACIParameters, VerifyTally {
+contract MACI is DomainObjs, ComputeRoot, MACIParameters, VerifyTally {
 
     // A nothing-up-my-sleeve zero value
     // Should be equal to 5503045433092194285660061905880311622788666850989422096966288514930349325741
@@ -125,7 +124,7 @@ contract MACI is Ownable, DomainObjs, ComputeRoot, MACIParameters, VerifyTally {
         uint256 _votingDurationSeconds,
         InitialVoiceCreditProxy _initialVoiceCreditProxy,
         PubKey memory _coordinatorPubKey
-    ) Ownable() public {
+    ) public {
 
         treeDepths = _treeDepths;
 


### PR DESCRIPTION
There are no `onlyOwner` methods in MACI contract, so I propose to remove `Ownable` from the list of base classes. That would save ~800 bytes in contract size.