### PR TITLE
Enforce the voice credit limit in the MACI contract (2 ^ 32)

### DIFF
--- a/contracts/sol/MACI.sol
+++ b/contracts/sol/MACI.sol
@@ -272,6 +272,11 @@ contract MACI is DomainObjs, ComputeRoot, MACIParameters, VerifyTally {
             _initialVoiceCreditProxyData
         );
 
+        // The limit on voice credits is 2 ^ 32 which is hardcoded into the
+        // UpdateStateTree circuit, specifically at check that there are
+        // sufficient voice credits (using GreaterEqThan(32)).
+        require(voiceCreditBalance <= 4294967296, "MACI: too many voice credits");
+
         // Create, hash, and insert a fresh state leaf
         StateLeaf memory stateLeaf = StateLeaf({
             pubKey: _userPubKey,

--- a/contracts/ts/deploy.ts
+++ b/contracts/ts/deploy.ts
@@ -58,7 +58,7 @@ const deployConstantInitialVoiceCreditProxy = async (
     quiet = false
 ) => {
     log('Deploying InitialVoiceCreditProxy', quiet)
-    return await deployer.deploy(ConstantInitialVoiceCreditProxy, {}, amount)
+    return await deployer.deploy(ConstantInitialVoiceCreditProxy, {}, amount.toString())
 }
 
 const deploySignupToken = async (deployer) => {


### PR DESCRIPTION
@xuhcc found a bug (#155) where an vote with too many credits prevents vote processing as the `UpdateStateTree` circuit only supports a maximum of `2^32` voice credits. 

This PR enforces this limit in the `MACI.signUp()` contract function.