### PR TITLE
Export 'process' and 'tally' commands from maci-cli module

### DIFF
--- a/cli/ts/index.ts
+++ b/cli/ts/index.ts
@@ -95,8 +95,12 @@ const main = async () => {
         await publish(args)
     } else if (args.subcommand === 'process') {
         await processMessages(args)
+        // Force the process to exit as it might get stuck
+        process.exit()
     } else if (args.subcommand === 'tally') {
         await tally(args)
+        // Force the process to exit as it might get stuck
+        process.exit()
     } else if (args.subcommand === 'verify') {
         await verify(args)
     }
@@ -107,6 +111,8 @@ if (require.main === module) {
 }
 
 export {
+    processMessages,
+    tally,
     calcBinaryTreeDepthFromMaxLeaves,
     calcQuinTreeDepthFromMaxLeaves,
 }

--- a/cli/ts/process.ts
+++ b/cli/ts/process.ts
@@ -108,7 +108,7 @@ const configureSubparser = (subparsers: any) => {
 
 // This function is named as such as there already is a global Node.js object
 // called 'process'
-const processMessages = async (args: any) => {
+const processMessages = async (args: any): Promise<string | undefined> => {
     // MACI contract
     if (!validateEthAddress(args.contract)) {
         console.error('Error: invalid MACI contract address')
@@ -299,9 +299,7 @@ const processMessages = async (args: any) => {
             break
         }
     }
-
-    // Force the process to exit as it might get stuck
-    process.exit()
+    return randomStateLeaf.serialize()
 }
 
 export {

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "extends": "../tsconfig.json",
     "compilerOptions": {
-        "outDir": "./build"
+        "outDir": "./build",
+        "declaration": true
     },
     "include": [
         "./ts"

--- a/integrationTests/ts/__tests__/utils.ts
+++ b/integrationTests/ts/__tests__/utils.ts
@@ -1,7 +1,5 @@
 import * as shell from 'shelljs'
 
-import { calcTreeDepthFromMaxLeaves } from 'maci-cli'
-
 const exec = (command: string) => {
     return shell.exec(command, { silent: true })
 }
@@ -10,4 +8,4 @@ const delay = (ms: number): Promise<void> => {
     return new Promise((resolve: Function) => setTimeout(resolve, ms))
 }
 
-export { exec, delay, calcTreeDepthFromMaxLeaves }
+export { exec, delay }


### PR DESCRIPTION
Exporting `processMessages` and `tally` functions from `maci-cli` module to simplify integrations.