### PR TITLE
Fix OZ import paths in solidity files

### DIFF
--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -619,6 +619,11 @@
 				"@types/yargs": "^13.0.0"
 			}
 		},
+		"@openzeppelin/contracts": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.1.tgz",
+			"integrity": "sha512-qIy6tLx8rtybEsIOAlrM4J/85s2q2nPkDqj/Rx46VakBZ0LwtFhXIVub96LXHczQX0vaqmAueDqNPXtbSXSaYQ=="
+		},
 		"@sindresorhus/is": {
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -6594,11 +6599,6 @@
 					"dev": true
 				}
 			}
-		},
-		"openzeppelin-solidity": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.5.1.tgz",
-			"integrity": "sha512-oCGtQPLOou4su76IMr4XXJavy9a8OZmAXeUZ8diOdFznlL/mlkIlYr7wajqCzH4S47nlKPS7m0+a2nilCTpVPQ=="
 		},
 		"optimist": {
 			"version": "0.6.1",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -29,10 +29,10 @@
         "@maci-contracts": "."
     },
     "dependencies": {
+        "@openzeppelin/contracts": "^2.4.0",
         "argparse": "^1.0.10",
         "circomlib": "0.2.4",
-        "module-alias": "^2.2.2",
-        "openzeppelin-solidity": "^2.4.0"
+        "module-alias": "^2.2.2"
     },
     "devDependencies": {
         "@types/jest": "^24.0.25",

--- a/contracts/scripts/compileSol.sh
+++ b/contracts/scripts/compileSol.sh
@@ -21,10 +21,11 @@ wget -nc -q -O $solcBin https://github.com/ethereum/solidity/releases/download/v
 chmod a+x $solcBin
 
 paths="$(pwd)/sol/,$(pwd)/node_modules/openzeppelin-solidity/"
+oz_map="@openzeppelin-solidity/=$(pwd)/node_modules/openzeppelin-solidity/"
 
 echo 'Building contracts'
-$solcBin -o ./compiled ./sol/*.sol --overwrite --optimize --bin --abi --bin-runtime --allow-paths=$paths
-$solcBin -o ./compiled ./sol/**/*.sol --overwrite --optimize --bin --abi --bin-runtime --allow-paths=$paths
+$solcBin $oz_map -o ./compiled ./sol/*.sol --overwrite --optimize --bin --abi --bin-runtime --allow-paths=$paths
+$solcBin $oz_map -o ./compiled ./sol/**/*.sol --overwrite --optimize --bin --abi --bin-runtime --allow-paths=$paths
 
 # Build the Poseidon contract from bytecode
 node build/buildPoseidon.js

--- a/contracts/scripts/compileSol.sh
+++ b/contracts/scripts/compileSol.sh
@@ -20,8 +20,8 @@ solcBin=$(pwd)/solc
 wget -nc -q -O $solcBin https://github.com/ethereum/solidity/releases/download/v0.5.17/solc-static-linux
 chmod a+x $solcBin
 
-paths="$(pwd)/sol/,$(pwd)/node_modules/openzeppelin-solidity/"
-oz_map="@openzeppelin-solidity/=$(pwd)/node_modules/openzeppelin-solidity/"
+paths="$(pwd)/sol/,$(pwd)/node_modules/@openzeppelin/"
+oz_map="@openzeppelin/=$(pwd)/node_modules/@openzeppelin/"
 
 echo 'Building contracts'
 $solcBin $oz_map -o ./compiled ./sol/*.sol --overwrite --optimize --bin --abi --bin-runtime --allow-paths=$paths

--- a/contracts/sol/IncrementalMerkleTree.sol
+++ b/contracts/sol/IncrementalMerkleTree.sol
@@ -23,7 +23,7 @@ pragma solidity ^0.5.0;
 
 import { SnarkConstants } from "./SnarkConstants.sol";
 import { Hasher } from "./Hasher.sol";
-import { Ownable } from "../node_modules/openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import { Ownable } from "@openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 contract IncrementalMerkleTree is Ownable, Hasher {
     // The maximum tree depth

--- a/contracts/sol/IncrementalMerkleTree.sol
+++ b/contracts/sol/IncrementalMerkleTree.sol
@@ -23,7 +23,7 @@ pragma solidity ^0.5.0;
 
 import { SnarkConstants } from "./SnarkConstants.sol";
 import { Hasher } from "./Hasher.sol";
-import { Ownable } from "@openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import { Ownable } from "@openzeppelin/contracts/ownership/Ownable.sol";
 
 contract IncrementalMerkleTree is Ownable, Hasher {
     // The maximum tree depth

--- a/contracts/sol/IncrementalQuinTree.sol
+++ b/contracts/sol/IncrementalQuinTree.sol
@@ -23,7 +23,7 @@ pragma solidity ^0.5.0;
 
 import { SnarkConstants } from "./SnarkConstants.sol";
 import { Hasher } from "./Hasher.sol";
-import { Ownable } from "@openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import { Ownable } from "@openzeppelin/contracts/ownership/Ownable.sol";
 
 /*
  * An incremental Merkle tree which supports up to 5 leaves per node.

--- a/contracts/sol/IncrementalQuinTree.sol
+++ b/contracts/sol/IncrementalQuinTree.sol
@@ -23,7 +23,7 @@ pragma solidity ^0.5.0;
 
 import { SnarkConstants } from "./SnarkConstants.sol";
 import { Hasher } from "./Hasher.sol";
-import { Ownable } from "../node_modules/openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import { Ownable } from "@openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 /*
  * An incremental Merkle tree which supports up to 5 leaves per node.

--- a/contracts/sol/SignUpToken.sol
+++ b/contracts/sol/SignUpToken.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.0;
 
-import "../node_modules/openzeppelin-solidity/contracts/token/ERC721/ERC721Full.sol";
-import "../node_modules/openzeppelin-solidity/contracts/token/ERC721/ERC721Mintable.sol";
-import "../node_modules/openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "@openzeppelin-solidity/contracts/token/ERC721/ERC721Full.sol";
+import "@openzeppelin-solidity/contracts/token/ERC721/ERC721Mintable.sol";
+import "@openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 contract SignUpToken is ERC721Full, ERC721Mintable, Ownable {
   // Keeps track of total tokens

--- a/contracts/sol/SignUpToken.sol
+++ b/contracts/sol/SignUpToken.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.0;
 
-import "@openzeppelin-solidity/contracts/token/ERC721/ERC721Full.sol";
-import "@openzeppelin-solidity/contracts/token/ERC721/ERC721Mintable.sol";
-import "@openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721Full.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721Mintable.sol";
+import "@openzeppelin/contracts/ownership/Ownable.sol";
 
 contract SignUpToken is ERC721Full, ERC721Mintable, Ownable {
   // Keeps track of total tokens

--- a/contracts/ts/deploy.ts
+++ b/contracts/ts/deploy.ts
@@ -55,12 +55,15 @@ const linkPoseidonContracts = (
     }
 
     const d = path.join(__dirname, '..')
-    const allowedPaths = `${path.join(d, 'sol')}/,${path.join(d, 'node_modules', 'openzeppelin-solidity')}`
+    const maciSolPath = path.join(d, 'sol')
+    const ozSolPath = path.join(d, 'node_modules', 'openzeppelin-solidity')
 
     const poseidonPath = path.join(__dirname, '..', 'sol', 'Poseidon.sol')
     const solcPath = path.join(__dirname, '..', 'solc')
-    const linkCmd = `${solcPath} -o ${abiDir} ${inputFiles} --overwrite --bin `
-        + ` --allow-paths ${allowedPaths}`
+    const linkCmd = `${solcPath}`
+        + ` @openzeppelin-solidity/=${ozSolPath}/`
+        + ` -o ${abiDir} ${inputFiles} --overwrite --bin`
+        + ` --allow-paths ${maciSolPath}/,${ozSolPath}`
         + ` --libraries ${poseidonPath}:PoseidonT3:${poseidonT3Address}`
         + ` --libraries ${poseidonPath}:PoseidonT6:${poseidonT6Address}`
 

--- a/contracts/ts/deploy.ts
+++ b/contracts/ts/deploy.ts
@@ -56,12 +56,12 @@ const linkPoseidonContracts = (
 
     const d = path.join(__dirname, '..')
     const maciSolPath = path.join(d, 'sol')
-    const ozSolPath = path.join(d, 'node_modules', 'openzeppelin-solidity')
+    const ozSolPath = path.join(d, 'node_modules', '@openzeppelin')
 
     const poseidonPath = path.join(__dirname, '..', 'sol', 'Poseidon.sol')
     const solcPath = path.join(__dirname, '..', 'solc')
     const linkCmd = `${solcPath}`
-        + ` @openzeppelin-solidity/=${ozSolPath}/`
+        + ` @openzeppelin/=${ozSolPath}/`
         + ` -o ${abiDir} ${inputFiles} --overwrite --bin`
         + ` --allow-paths ${maciSolPath}/,${ozSolPath}`
         + ` --libraries ${poseidonPath}:PoseidonT3:${poseidonT3Address}`


### PR DESCRIPTION
This prevents import errors when yarn package manager is used:

```
File maci-contracts/node_modules/openzeppelin-solidity/contracts/ownership/Ownable.sol, imported from maci-contracts/sol/IncrementalQuinTree.sol, not found.
```

I also switched to `@openzeppelin/contracts` package as recommended at https://github.com/OpenZeppelin/openzeppelin-contracts

Resolves #172