### PR TITLE
Fix the postSignUpStateRoot bug

### DIFF
--- a/cli/ts/process.ts
+++ b/cli/ts/process.ts
@@ -281,8 +281,8 @@ const processMessages = async (args: any): Promise<string | undefined> => {
             break
         }
 
-        const postSignUpStateRoot = await maciContract.postSignUpStateRoot()
-        if (postSignUpStateRoot.toString() !== stateRootAfter.toString()) {
+        const stateRoot = await maciContract.stateRoot()
+        if (stateRoot.toString() !== stateRootAfter.toString()) {
             console.error('Error: state root mismatch after processing a batch of messges')
             return
         }

--- a/cli/ts/utils.ts
+++ b/cli/ts/utils.ts
@@ -113,7 +113,6 @@ const genMaciStateFromContract = async (
 
     // Process the messages so that the users array is up to date with the
     // contract's state tree
-    const postSignUpStateRoot = await maciContract.postSignUpStateRoot()
     const currentMessageBatchIndex = Number((await maciContract.currentMessageBatchIndex()).toString())
     const messageBatchSize = Number((await maciContract.messageBatchSize()).toString())
     const numMessages = maciState.messages.length
@@ -142,10 +141,6 @@ const genMaciStateFromContract = async (
                 zerothLeaf,
             )
         }
-    }
-
-    if (maciState.genStateRoot().toString(16) !== BigInt(postSignUpStateRoot).toString(16)) {
-        throw new Error('Error: could not correctly process messages to recreate the state')
     }
 
     return maciState


### PR DESCRIPTION
There is a bug where the contract only updates a copy of the state root when `publishMessage` is first called. This PR fixes this by updating that copy of the state root every time we call `signUp`.