### PR TITLE
Crypto: fix `hash5`

### DIFF
--- a/crypto/ts/__tests__/Crypto.test.ts
+++ b/crypto/ts/__tests__/Crypto.test.ts
@@ -36,6 +36,11 @@ describe('Cryptographic operations', () => {
             const h = hash5(plaintext)
             expect(h < SNARK_FIELD_SIZE).toBeTruthy()
         })
+        it('Padding to 5 if length of elements is less than 5', () => {
+            const h = hash5([BigInt(1)])
+            const hElementsPadded = hash5([BigInt(1), BigInt(0), BigInt(0), BigInt(0), BigInt(0)])
+            expect(h).toEqual(hElementsPadded);
+        })
     })
 
     describe('Hash11', () => {

--- a/crypto/ts/index.ts
+++ b/crypto/ts/index.ts
@@ -79,7 +79,7 @@ const hash5 = (elements: Plaintext): BigInt => {
             elementsPadded.push(BigInt(0))
         }
     }
-    return poseidonT6(elements)
+    return poseidonT6(elementsPadded)
 }
 
 /*


### PR DESCRIPTION
In `hash5`, `elements` is passed to `poseidonT6` instead of `elementsPadded`, which is the one ought to be used.