### PR TITLE
Add snarkParamsPath config parameter

### DIFF
--- a/.circleci/config.yml.deprecated
+++ b/.circleci/config.yml.deprecated
@@ -80,16 +80,16 @@ jobs:
       - save_cache:
           key: v1.3-built-snarks
           paths:
-            - circuits/build/pot19_final.ptau
-            - circuits/build/BatchUpdateStateTreeVerifier.sol
-            - circuits/build/batchUstCircuit.r1cs
-            - circuits/build/batchUst.wasm
-            - circuits/build/batchUst.zkey
-            - circuits/build/batchUstVk.json
-            - circuits/build/QuadVoteTallyVerifier.sol
-            - circuits/build/qvtCircuit.r1cs
-            - circuits/build/qvt.wasm
-            - circuits/build/qvtVk.json
+            - circuits/params/pot19_final.ptau
+            - circuits/params/BatchUpdateStateTreeVerifier.sol
+            - circuits/params/batchUstCircuit.r1cs
+            - circuits/params/batchUst.wasm
+            - circuits/params/batchUst.zkey
+            - circuits/params/batchUstVk.json
+            - circuits/params/QuadVoteTallyVerifier.sol
+            - circuits/params/qvtCircuit.r1cs
+            - circuits/params/qvt.wasm
+            - circuits/params/qvtVk.json
 
       - run:
           name: Lint
@@ -120,4 +120,4 @@ jobs:
           command: cd integrationTests && ./scripts/runTestsInCircleCi.sh
 
       - store_artifacts:
-          path: circuits/build
+          path: circuits/params

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ deployedAddresses.json
 .etherlime-store
 **/build/
 circuits/build
+circuits/params
 contracts/compiled
 contracts/sol/BatchUpdateStateTreeVerifierSmall.sol
 contracts/sol/QuadVoteTallyVerifierSmall.sol

--- a/circuits/scripts/buildBatchUpdateStateTreeSnark.sh
+++ b/circuits/scripts/buildBatchUpdateStateTreeSnark.sh
@@ -4,9 +4,9 @@ set -e
 
 cd "$(dirname "$0")"
 cd ..
-mkdir -p build
+mkdir -p params
 
-NODE_OPTIONS=--max-old-space-size=8192 node build/buildSnarks.js -i circom/test/batchUpdateStateTree_test.circom -j build/batchUstCircuit.r1cs -w build/batchUst.wasm -y build/batchUst.sym -p build/batchUstPk.json -v build/batchUstVk.json -s build/BatchUpdateStateTreeVerifier.sol -vs BatchUpdateStateTreeVerifier -pr build/batchUst.params
+NODE_OPTIONS=--max-old-space-size=8192 node build/buildSnarks.js -i circom/test/batchUpdateStateTree_test.circom -j params/batchUstCircuit.r1cs -w params/batchUst.wasm -y params/batchUst.sym -p params/batchUstPk.json -v params/batchUstVk.json -s params/BatchUpdateStateTreeVerifier.sol -vs BatchUpdateStateTreeVerifier -pr params/batchUst.params
 
 echo 'Copying BatchUpdateStateTreeVerifier.sol to contracts/sol.'
-cp ./build/BatchUpdateStateTreeVerifier.sol ../contracts/sol/
+cp ./params/BatchUpdateStateTreeVerifier.sol ../contracts/sol/

--- a/circuits/scripts/buildQuadVoteTallySnark.sh
+++ b/circuits/scripts/buildQuadVoteTallySnark.sh
@@ -4,9 +4,9 @@ set -e
 
 cd "$(dirname "$0")"
 cd ..
-mkdir -p build
+mkdir -p params
 
-NODE_OPTIONS=--max-old-space-size=8192 node build/buildSnarks.js -i circom/test/quadVoteTally_test.circom -j build/qvtCircuit.r1cs -w build/qvt.wasm -y build/qvt.sym -p build/qvtPk.bin -v build/qvtVk.json -s build/QuadVoteTallyVerifier.sol -vs QuadVoteTallyVerifier -pr build/qvt.params
+NODE_OPTIONS=--max-old-space-size=8192 node build/buildSnarks.js -i circom/test/quadVoteTally_test.circom -j params/qvtCircuit.r1cs -w params/qvt.wasm -y params/qvt.sym -p params/qvtPk.bin -v params/qvtVk.json -s params/QuadVoteTallyVerifier.sol -vs QuadVoteTallyVerifier -pr params/qvt.params
 
 echo 'Copying QuadVoteTallyVerifier.sol to contracts/sol.'
-cp ./build/QuadVoteTallyVerifier.sol ../contracts/sol/
+cp ./params/QuadVoteTallyVerifier.sol ../contracts/sol/

--- a/circuits/scripts/buildSnarksSmall.sh
+++ b/circuits/scripts/buildSnarksSmall.sh
@@ -4,16 +4,16 @@ set -e
 
 cd "$(dirname "$0")"
 cd ..
-mkdir -p build
+mkdir -p params
 
 echo "Building batchUpdateStateTree_small"
-NODE_OPTIONS=--max-old-space-size=16384 node --stack-size=16384 build/buildSnarks.js -i circom/prod/batchUpdateStateTree_small.circom -j build/batchUstSmall.r1cs -w build/batchUstSmall.wasm -y build/batchUstSmall.sym -p build/batchUstPkSmall.json -v build/batchUstVkSmall.json -s build/BatchUpdateStateTreeVerifierSmall.sol -vs BatchUpdateStateTreeVerifierSmall -pr build/batchUstSmall.params
+NODE_OPTIONS=--max-old-space-size=16384 node --stack-size=16384 build/buildSnarks.js -i circom/prod/batchUpdateStateTree_small.circom -j params/batchUstSmall.r1cs -w params/batchUstSmall.wasm -y params/batchUstSmall.sym -p params/batchUstPkSmall.json -v params/batchUstVkSmall.json -s params/BatchUpdateStateTreeVerifierSmall.sol -vs BatchUpdateStateTreeVerifierSmall -pr params/batchUstSmall.params
 
 echo "Building quadVoteTally_small"
-NODE_OPTIONS=--max-old-space-size=16384 node --stack-size=16384 build/buildSnarks.js -i circom/prod/quadVoteTally_small.circom -j build/qvtCircuitSmall.r1cs -w build/qvtSmall.wasm -y build/qvtSmall.sym -p build/qvtPkSmall.bin -v build/qvtVkSmall.json -s build/QuadVoteTallyVerifierSmall.sol -vs QuadVoteTallyVerifierSmall -pr build/qvtSmall.params
+NODE_OPTIONS=--max-old-space-size=16384 node --stack-size=16384 build/buildSnarks.js -i circom/prod/quadVoteTally_small.circom -j params/qvtCircuitSmall.r1cs -w params/qvtSmall.wasm -y params/qvtSmall.sym -p params/qvtPkSmall.bin -v params/qvtVkSmall.json -s params/QuadVoteTallyVerifierSmall.sol -vs QuadVoteTallyVerifierSmall -pr params/qvtSmall.params
 
 echo 'Copying BatchUpdateStateTreeVerifier.sol to contracts/sol.'
-cp ./build/BatchUpdateStateTreeVerifierSmall.sol ../contracts/sol/
+cp ./params/BatchUpdateStateTreeVerifierSmall.sol ../contracts/sol/
 
 echo 'Copying QuadVoteTallyVerifier.sol to contracts/sol.'
-cp ./build/QuadVoteTallyVerifierSmall.sol ../contracts/sol/
+cp ./params/QuadVoteTallyVerifierSmall.sol ../contracts/sol/

--- a/circuits/ts/index.ts
+++ b/circuits/ts/index.ts
@@ -12,6 +12,9 @@ import {
 
 import { config } from 'maci-config'
 const zkutilPath = config.zkutil_bin
+const snarkParamsPath = path.isAbsolute(config.snarkParamsPath)
+    ? config.snarkParamsPath
+    : path.resolve(config.snarkParamsPath)
 
 /*
  * @param circuitPath The subpath to the circuit file (e.g.
@@ -59,7 +62,7 @@ const getSignalByNameViaSym = (
     witness: any,
     signal: string,
 ) => {
-    const symPath = path.join(__dirname, '../build/', `${circuitName}.sym`)
+    const symPath = path.join(snarkParamsPath, `${circuitName}.sym`)
     const liner = new lineByLine(symPath)
     let line
     let index
@@ -156,14 +159,14 @@ const genProofAndPublicSignals = async (
     compileCircuit = true,
 ) => {
     const date = Date.now()
-    const paramsPath = path.join(__dirname, '../build/', paramsFilename)
-    const circuitR1csPath = path.join(__dirname, '../build/', circuitR1csFilename)
-    const circuitWasmPath = path.join(__dirname, '../build/', circuitWasmFilename)
-    const inputJsonPath = path.join(__dirname, '../build/' + date + '.input.json')
-    const witnessPath = path.join(__dirname, '../build/' + date + '.witness.wtns')
-    const witnessJsonPath = path.join(__dirname, '../build/' + date + '.witness.json')
-    const proofPath = path.join(__dirname, '../build/' + date + '.proof.json')
-    const publicJsonPath = path.join(__dirname, '../build/' + date + '.publicSignals.json')
+    const paramsPath = path.join(snarkParamsPath, paramsFilename)
+    const circuitR1csPath = path.join(snarkParamsPath, circuitR1csFilename)
+    const circuitWasmPath = path.join(snarkParamsPath, circuitWasmFilename)
+    const inputJsonPath = path.join(snarkParamsPath, date + '.input.json')
+    const witnessPath = path.join(snarkParamsPath, date + '.witness.wtns')
+    const witnessJsonPath = path.join(snarkParamsPath, date + '.witness.json')
+    const proofPath = path.join(snarkParamsPath, date + '.proof.json')
+    const publicJsonPath = path.join(snarkParamsPath, date + '.publicSignals.json')
 
     fs.writeFileSync(inputJsonPath, JSON.stringify(stringifyBigInts(inputs)))
 
@@ -210,9 +213,9 @@ const verifyProof = async (
     proofFilename: string,
     publicSignalsFilename: string,
 ): Promise<boolean> => {
-    const paramsPath = path.join(__dirname, '../build/', paramsFilename)
-    const proofPath = path.join(__dirname, '../build/', proofFilename)
-    const publicSignalsPath = path.join(__dirname, '../build/', publicSignalsFilename)
+    const paramsPath = path.join(snarkParamsPath, paramsFilename)
+    const proofPath = path.join(snarkParamsPath, proofFilename)
+    const publicSignalsPath = path.join(snarkParamsPath, publicSignalsFilename)
 
     const verifyCmd = `${zkutilPath} verify -p ${paramsPath} -r ${proofPath} -i ${publicSignalsPath}`
     const output = shell.exec(verifyCmd).stdout.trim()
@@ -244,14 +247,14 @@ const verifyBatchUstProof = (
     }
 
     fs.writeFileSync(
-        path.join(__dirname, '../build/', proofFilename),
+        path.join(snarkParamsPath, proofFilename),
         JSON.stringify(
             stringifyBigInts(proof)
         )
     )
 
     fs.writeFileSync(
-        path.join(__dirname, '../build/', publicSignalsFilename),
+        path.join(snarkParamsPath, publicSignalsFilename),
         JSON.stringify(
             stringifyBigInts(publicSignals)
         )
@@ -282,14 +285,14 @@ const verifyQvtProof = (
 
     // TODO: refactor
     fs.writeFileSync(
-        path.join(__dirname, '../build/', proofFilename),
+        path.join(snarkParamsPath, proofFilename),
         JSON.stringify(
             stringifyBigInts(proof)
         )
     )
 
     fs.writeFileSync(
-        path.join(__dirname, '../build/', publicSignalsFilename),
+        path.join(snarkParamsPath, publicSignalsFilename),
         JSON.stringify(
             stringifyBigInts(publicSignals)
         )

--- a/config/prod-small.yaml
+++ b/config/prod-small.yaml
@@ -22,4 +22,5 @@ chain:
   ganache:
     port: 8545
 
+snarkParamsPath: '../circuits/params/'
 zkutil_bin: "~/.cargo/bin/zkutil"

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -22,4 +22,5 @@ chain:
   ganache:
     port: 8545
 
+snarkParamsPath: '../circuits/params/'
 zkutil_bin: "~/.cargo/bin/zkutil"


### PR DESCRIPTION
- Added config parameter `snarkParamsPath` which should resolve #197.
- Changed default directory where snark build artifacts are collected to `circuits/params`, so now they are stored separately from JS files (`circuits/build`).