### PR TITLE
Fix resolution of relative snark params path

### DIFF
--- a/circuits/ts/index.ts
+++ b/circuits/ts/index.ts
@@ -14,7 +14,7 @@ import { config } from 'maci-config'
 const zkutilPath = config.zkutil_bin
 const snarkParamsPath = path.isAbsolute(config.snarkParamsPath)
     ? config.snarkParamsPath
-    : path.resolve(config.snarkParamsPath)
+    : path.resolve(__dirname, config.snarkParamsPath)
 
 /*
  * @param circuitPath The subpath to the circuit file (e.g.

--- a/config/prod-small.yaml
+++ b/config/prod-small.yaml
@@ -22,5 +22,5 @@ chain:
   ganache:
     port: 8545
 
-snarkParamsPath: '../circuits/params/'
+snarkParamsPath: '../params/'
 zkutil_bin: "~/.cargo/bin/zkutil"

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -22,5 +22,5 @@ chain:
   ganache:
     port: 8545
 
-snarkParamsPath: '../circuits/params/'
+snarkParamsPath: '../params/'
 zkutil_bin: "~/.cargo/bin/zkutil"


### PR DESCRIPTION
I get this error with `maci-circuits 0.5.6`:

```
Error: ENOENT: no such file or directory, open `./project-dir/circuits/params/1612548070018.input.json'
```

The packaged script treats `snarkParamsPath` as relative to current working directory but it must treat it as relative to script itself. This patch should fix it.


