### PR TITLE
Fix .sol compilation to work in directories which are symlinks

### DIFF
--- a/contracts/scripts/compileSol.sh
+++ b/contracts/scripts/compileSol.sh
@@ -25,9 +25,9 @@ solcBin=$(pwd)/solc
 wget -nc -q -O $solcBin https://github.com/ethereum/solidity/releases/download/v0.6.12/${solcPlatform}
 chmod a+x $solcBin
 
-paths="$(pwd)/sol/,$(pwd)/node_modules/@openzeppelin/"
-oz_map="@openzeppelin/=$(pwd)/node_modules/@openzeppelin/"
-
+pwd="$(pwd -P)"
+paths="$pwd/sol/,$pwd/node_modules/@openzeppelin/"
+oz_map="@openzeppelin/=$pwd/node_modules/@openzeppelin/"
 ./scripts/writeMerkleZeroesContracts.sh
 
 echo 'Building contracts'


### PR DESCRIPTION
If a `.sol` file being compiled lives in a directory path which contains a symlink component, then the `--allowed-paths` option of `solc` only works when the symlinks are fully resolved.  So use `pwd -P` to obtain the absolute paths instead of just `pwd`.