### PR TITLE
Clarify how to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,29 @@ cd contracts
 npm run ganache
 ```
 
-In another terminal, run the tests individually:
+In another terminal, run any of the tests found in `contracts/ts/__tests__/`
+via pattern matching, e.g.:
+
+```bash
+cd contracts
+npx jest IncrementalMerkleTree
+```
+
+would run `IncrementalMerkleTree.test.ts`.
+
+N.B. `npx jest Tree` would run that and `IncrementalQuinTree.test.ts`
+in parallel, causing incorrect nonce errors.
+
+Alternatively you can run all unit tests as follows, but you should
+stop your Ganache instance first as this will start its own instance
+before running the tests:
 
 ```bash
 cd contracts
 ./scripts/runTestsInCircleCi.sh
 ```
 
-or
+Or run all integration tests (this also starts its own Ganache instance):
 
 ```bash
 cd integrationTests


### PR DESCRIPTION
The existing instructions did not work, because they instructed the user to start their own Ganache instance, which would then conflict with the ones started by the scripts.  So clarify this, and also explain how to run individual tests one by one, which is what the `README` already recommended anyway to prevent incorrect nonce errors.