### PR TITLE
Contract initialize tally

### DIFF
--- a/circuits/circom/tallyVotes.circom
+++ b/circuits/circom/tallyVotes.circom
@@ -132,12 +132,15 @@ template TallyVotes(
         voteTree[i].root === ballots[i][BALLOT_VO_ROOT_IDX];
     }
 
+    component isFirstBatch = IsZero();
+    isFirstBatch.in <== batchStartIndex;
+
     //  ----------------------------------------------------------------------- 
     // Tally the new results
     component resultCalc[numVoteOptions];
     for (var i = 0; i < numVoteOptions; i ++) {
         resultCalc[i] = CalculateTotal(batchSize + 1);
-        resultCalc[i].nums[batchSize] <== currentResults[i];
+        resultCalc[i].nums[batchSize] <== currentResults[i] * isFirstBatch.out;
         for (var j = 0; j < batchSize; j ++) {
             resultCalc[i].nums[j] <== votes[j][i];
         }
@@ -162,9 +165,6 @@ template TallyVotes(
             newPerVOSpentVoiceCredits[i].nums[j] <== votes[j][i] * votes[j][i];
         }
     }
-
-    component isFirstBatch = IsZero();
-    isFirstBatch.in <== batchStartIndex;
 
     // Verify the current and new tally
     component rcv = ResultCommitmentVerifier(voteOptionTreeDepth);
@@ -273,7 +273,7 @@ template ResultCommitmentVerifier(voteOptionTreeDepth) {
     // Compute the root of the new results
     component newResultsRoot = QuinCheckRoot(voteOptionTreeDepth);
     for (var i = 0; i < numVoteOptions; i ++) {
-        newResultsRoot.leaves[i] <== newResults[i];
+        newResultsRoot.leaves[i] <== newResults[i] * iz.out;
     }
 
     component newResultsCommitment = HashLeftRight();

--- a/cli/ts/deployPoll.ts
+++ b/cli/ts/deployPoll.ts
@@ -158,8 +158,16 @@ const deployPoll = async (args: any) => {
     // Deploy a PollProcessorAndTallyer contract
     const verifierContract = await deployVerifier(true)
     console.log('Verifier:', verifierContract.address)
-    const pptContract = await deployPpt(verifierContract.address, true)
-    await pptContract.deployTransaction.wait()
+
+    let pptContract;
+    try {
+        pptContract = await deployPpt(verifierContract.address, false)
+        await pptContract.deployTransaction.wait()
+    }
+    catch (e) {
+        console.error('Error: could not deploy PollProcessorAndTallyer')
+        console.error(e.message)
+    }
 
     const [ maciAbi ] = parseArtifact('MACI')
     const maciContract = new ethers.Contract(

--- a/cli/ts/proveOnChain.ts
+++ b/cli/ts/proveOnChain.ts
@@ -383,7 +383,10 @@ const proveOnChain = async (args: any) => {
             batchStartIndex,
             tallyBatchSize,
             circuitInputs.newTallyCommitment,
+            tallyBatchNum
         )
+
+
         if (publicInputHashOnChain.toString() !== publicInputs[0]) {
             console.error('Error: public input mismatch.')
             return 1

--- a/contracts/contracts/crypto/Hasher.sol
+++ b/contracts/contracts/crypto/Hasher.sol
@@ -23,6 +23,15 @@ library PoseidonT6 {
  * functions for 2, 3, 4, 5, and 12 input elements.
  */
 contract Hasher is SnarkConstants {
+    /*
+     * Hashes an array of values using SHA256 and returns its modulo with the
+     * snark scalar field. This function is used to hash inputs to circuits,
+     * where said inputs would otherwise be public inputs. As such, the only
+     * public input to the circuit is the SHA256 hash, and all others are
+     * private inputs. The circuit will verify that the hash is valid. Doing so
+     * saves a lot of gas during verification, though it makes the circuit take
+     * up more constraints.
+     */
     function sha256Hash(uint256[] memory array) public pure returns (uint256) {
         return uint256(sha256(abi.encodePacked(array))) % SNARK_SCALAR_FIELD;
     }


### PR DESCRIPTION
Just ignoring the fact that we would want to actually provide the merkle roots of spentVO and credits, this example is to show that the would need to be done causes the contract not to deploy as we've reached the size limit. The biggest culprit is the `Hasher` interface

@weijiekoh looks like we will just ensure the check in the circuit but not sure if the other avenue is available to us anyway