### PR TITLE
Add dockerfile as multibuild job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.8.0-buster AS builder
+FROM node:16-bullseye AS builder
 
 WORKDIR /maci
 COPY . /maci/
@@ -8,22 +8,24 @@ RUN npm i && \
     npm run build
 
 FROM builder AS circuits
+ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /maci/circuits
 COPY --from=builder /maci/circuits ./
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN apt-get update -qq --fix-missing && \
     apt-get install -qq -y curl build-essential libssl-dev libgmp-dev \
-                       libsodium-dev nlohmann-json3-dev git nasm
+        libsodium-dev nlohmann-json3-dev git nasm libgcc-s1 dialog apt-utils
 
+RUN wget http://launchpadlibrarian.net/531361873/libc6_2.33-0ubuntu5_amd64.deb && \
+dpkg --auto-deconfigure -i libc6_2.33-0ubuntu5_amd64.deb || true
+RUN strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
 # Install zkutil
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
-RUN ~/.cargo/bin/cargo install zkutil
+# RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+#RUN ~/.cargo/bin/cargo install zkutil
 
 # RUN echo "deb http://ftp.us.debian.org/debian sid main" >> /etc/apt/sources.list
 # RUN apt-get -t unstable install libgcc-s1
 
-# RUN wget http://launchpadlibrarian.net/531361873/libc6_2.33-0ubuntu5_amd64.deb && \
-# dpkg --auto-deconfigure -i libc6_2.33-0ubuntu5_amd64.deb || true
-# RUN ./scripts/runTestsInCi.sh
+#RUN ./scripts/runTestsInCi.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:15.8.0-buster AS builder
+
+WORKDIR /maci
+COPY . /maci/
+
+RUN npm i && \
+    npm run bootstrap && \
+    npm run build
+
+FROM builder AS circuits
+WORKDIR /maci/circuits
+COPY --from=builder /maci/circuits ./
+
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+RUN apt-get update -qq --fix-missing && \
+    apt-get install -qq -y curl build-essential libssl-dev libgmp-dev \
+                       libsodium-dev nlohmann-json3-dev git nasm
+
+# Install zkutil
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+RUN ~/.cargo/bin/cargo install zkutil
+
+# RUN echo "deb http://ftp.us.debian.org/debian sid main" >> /etc/apt/sources.list
+# RUN apt-get -t unstable install libgcc-s1
+
+# RUN wget http://launchpadlibrarian.net/531361873/libc6_2.33-0ubuntu5_amd64.deb && \
+# dpkg --auto-deconfigure -i libc6_2.33-0ubuntu5_amd64.deb || true
+# RUN ./scripts/runTestsInCi.sh
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,25 +7,35 @@ RUN npm i && \
     npm run bootstrap && \
     npm run build
 
+# Build circuits
 FROM builder AS circuits
 ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /maci/circuits
 COPY --from=builder /maci/circuits ./
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
 RUN apt-get update -qq --fix-missing && \
     apt-get install -qq -y curl build-essential libssl-dev libgmp-dev \
-        libsodium-dev nlohmann-json3-dev git nasm libgcc-s1 dialog apt-utils
+        libsodium-dev nlohmann-json3-dev git nasm libgcc-s1
 
+# Install updated glibc dependencies
 RUN wget http://launchpadlibrarian.net/531361873/libc6_2.33-0ubuntu5_amd64.deb && \
 dpkg --auto-deconfigure -i libc6_2.33-0ubuntu5_amd64.deb || true
-RUN strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
+RUN wget http://ftp.debian.org/debian/pool/main/g/gcc-11/gcc-11-base_11.2.0-8_amd64.deb && \
+dpkg --auto-deconfigure -i gcc-11-base_11.2.0-8_amd64.deb || true
+RUN wget http://ftp.debian.org/debian/pool/main/g/gcc-11/libstdc++6_11.2.0-8_amd64.deb && \
+dpkg --auto-deconfigure -i libstdc++6_11.2.0-8_amd64.deb || true
+
 # Install zkutil
-# RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
-#RUN ~/.cargo/bin/cargo install zkutil
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+RUN ~/.cargo/bin/cargo install zkutil
 
-# RUN echo "deb http://ftp.us.debian.org/debian sid main" >> /etc/apt/sources.list
-# RUN apt-get -t unstable install libgcc-s1
+RUN ./scripts/runTestsInCi.sh
 
-#RUN ./scripts/runTestsInCi.sh
+# TODO: Build integration tests
+# FROM builder AS integration
+
+# TODO: Build contracts
+# FROM builder AS contracts
 


### PR DESCRIPTION
Run ```docker build -t maci . ```

To provide some context on why we want this structure for each of the submodules, when we implement github actions for different parts of the code base we can stop the build process to specific tagged intermediate images see https://docs.docker.com/develop/develop-images/multistage-build/

Essentially this will allow us to copy over cached artifacts to different images that need to be rebuilt to test new code changes 