### PR TITLE
Add view functions to caculate state commitment

### DIFF
--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -375,7 +375,10 @@ contract Poll is
     }
 
     /*
-    * Verify the number of spent voice credits given a vote option
+    * @notice Verify the number of spent voice credits from the tally.json
+    * @param _totalSpent spent field retrieved in the totalSpentVoiceCredits object
+    * @param _totalSpentSalt the corresponding salt in the totalSpentVoiceCredit object
+    * @return valid a boolean representing successful verification
     */
     function verifySpentVoiceCredits(
         uint256 _totalSpent,
@@ -385,6 +388,14 @@ contract Poll is
         return ballotRoot == emptyBallotRoots[treeDepths.voteOptionTreeDepth - 1];
     }
 
+    /*
+    * @notice Verify the number of spent voice credits per vote option from the tally.json
+    * @param _voteOptionIndex the index of the vote option where credits were spent
+    * @param _spent the spent voice credits for a given vote option index
+    * @param _spentProof proof generated for the perVOSpentVoiceCredits
+    * @param _salt the corresponding salt given in the tally perVOSpentVoiceCredits object
+    * @return valid a boolean representing successful verification
+    */
     function verifyPerVOSpentVoiceCredits(
         uint256 _voteOptionIndex,
         uint256 _spent,
@@ -408,6 +419,17 @@ contract Poll is
         return currentSbCommitment == hash3(sb);
     }
 
+    /*
+    * @notice Verify the result generated of the tally.json
+    * @param _voteOptionIndex the index of the vote option to verify the correctness of the tally
+    * @param _tallyResult Flattened array of the tally 
+    * @param _tallyResultProof Corresponding proof of the tally result
+    * @param _tallyResultSalt the respective salt in the results object in the tally.json
+    * @param _spentVoiceCreditsHash hashLeftRight(number of spent voice credits, spent salt) 
+    * @param _perVOSpentVoiceCreditsHash hashLeftRight(merkle root of the no spent voice credits per vote option, perVOSpentVoiceCredits salt)
+    * @param _tallyCommitment newTallyCommitment field in the tally.json
+    * @return valid a boolean representing successful verification
+    */
     function verifyTallyResult(
         uint256 _voteOptionIndex,
         uint256 _tallyResult,
@@ -819,6 +841,16 @@ contract PollProcessorAndTallyer is
         tallyBatchNum ++;
     }
 
+    /*
+    * @notice Verify the tally proof using the verifiying key
+    * @param _poll contract address of the poll proof to be verified
+    * @param _proof the proof generated after processing all messages
+    * @param _numSignUps number of signups for a given poll
+    * @param _batchStartIndex the number of batches multiplied by the size of the batch
+    * @param _tallyBatchSize batch size for the tally
+    * @param _newTallyCommitment the tally commitment to be verified at a given batch index
+    * @return valid a boolean representing successful verification
+    */
     function verifyTallyProof(
         Poll _poll,
         uint256[8] memory _proof,

--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -366,6 +366,23 @@ contract Poll is
         extContracts.messageAq.insertSubTree(_messageSubRoot);
         // TODO: emit event
     }
+
+    /*
+    * Verify the number of spent voice credits given a vote option
+    */
+    function verifyPerVOSpentVoiceCredits(
+        uint256 _index,
+        uint256 _leaf
+    ) public view returns (bool) {
+        uint256 computedRoot = extContracts.messageAq.hashLevelLeaf(_index, _leaf);
+        uint256[3] memory sb;
+        sb[0] = computedRoot;
+        sb[1] = emptyBallotRoots[treeDepths.voteOptionTreeDepth - 1];
+        sb[2] = uint256(0);
+
+        uint256 sbCommitment = hash3(sb);
+        return sbCommitment == currentSbCommitment;
+    }
 }
 
 contract PollProcessorAndTallyer is

--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -408,6 +408,30 @@ contract Poll is
         return currentSbCommitment == hash3(sb);
     }
 
+    function verifyTallyResult(
+        uint256 _voteOptionIndex,
+        uint256 _tallyResult,
+        uint256[][] memory _tallyResultProof,
+        uint256 _tallyResultSalt,
+        uint256 _spentVoiceCreditsHash,
+        uint256 _perVOSpentVoiceCreditsHash,
+        uint256 _tallyCommitment
+    ) public view returns (bool){
+         uint256 computedRoot = computeMerkleRootFromPath(
+            treeDepths.voteOptionTreeDepth,
+            _voteOptionIndex,
+            _tallyResult,
+            _tallyResultProof
+        );
+
+        uint256[3] memory tally;
+        tally[0] = computedRoot;
+        tally[1] = _spentVoiceCreditsHash;
+        tally[2] = _perVOSpentVoiceCreditsHash;
+
+        return hash3(tally) == _tallyCommitment;
+    }
+
 
     function computeMerkleRootFromPath(
         uint8 _depth,
@@ -793,24 +817,6 @@ contract PollProcessorAndTallyer is
         // Update the tally commitment and the tally batch num
         tallyCommitment = _newTallyCommitment;
         tallyBatchNum ++;
-    }
-
-    function verifyTallyResult(
-        uint256 _voteOptionIndex,
-        uint256 _tallyResult,
-        uint256[][] memory _tallyResultProof,
-        uint256 _tallyResultSalt
-    ) public view returns (bool){
-        /*
-         uint256 computedRoot = computeMerkleRootFromPath(
-            _poll.treeDepths.voteOptionTreeDepth,
-            _index,
-            _leaf,
-            _tallyResultProof
-        );
-        */
-        // return hash3(computedTally) == tallyCommitment;
-        return true;
     }
 
     function verifyTallyProof(

--- a/contracts/contracts/trees/AccQueue.sol
+++ b/contracts/contracts/trees/AccQueue.sol
@@ -112,6 +112,9 @@ abstract contract AccQueue is Ownable, Hasher {
     function hashLevel(uint256 _level, uint256 _leaf)
         virtual internal returns (uint256) {}
 
+    function hashLevelLeaf(uint256 _level, uint256 _leaf)
+        virtual view public returns (uint256) {}
+
     /*
      * Returns the zero leaf at a specified level.
      * This is a virtual function as the hash function which the overriding
@@ -506,6 +509,11 @@ abstract contract AccQueueBinary is AccQueue {
         return hashed;
     }
 
+    function hashLevelLeaf(uint256 _level, uint256 _leaf) override view public returns (uint256) {
+        uint256 hashed = hashLeftRight(leafQueue.levels[_level][0], _leaf);
+        return hashed;
+    }
+
     function _fill(uint256 _level) override internal {
         while (_level < subDepth) {
             uint256 n = leafQueue.indices[_level];
@@ -548,6 +556,18 @@ abstract contract AccQueueQuinary is AccQueue {
         // Free up storage slots to refund gas. Note that using a loop here
         // would result in lower gas savings.
         delete leafQueue.levels[_level];
+
+        return hashed;
+    }
+
+    function hashLevelLeaf(uint256 _level, uint256 _leaf) override view public returns (uint256) {
+        uint256[5] memory inputs;
+        inputs[0] = leafQueue.levels[_level][0];
+        inputs[1] = leafQueue.levels[_level][1];
+        inputs[2] = leafQueue.levels[_level][2];
+        inputs[3] = leafQueue.levels[_level][3];
+        inputs[4] = _leaf;
+        uint256 hashed = hash5(inputs);
 
         return hashed;
     }


### PR DESCRIPTION
Since we no longer separate commitments for voice options, this generates the commitment for the state tree. There are additional view functions to get the message leaf but this causes and exceeded contract size for mainnet. 

Not sure if this is a problem since deploying on xDai/L2 would be strongly recommended 