### PR TITLE
Multiple state AccQueues for more than one poll 

### DIFF
--- a/contracts/contracts/IMACI.sol
+++ b/contracts/contracts/IMACI.sol
@@ -7,9 +7,9 @@ interface IMACI {
 
     function stateTreeDepth() external view returns (uint8);
     function vkRegistry() external view returns (VkRegistry);
-    function getStateAqRoot() external view returns (uint256);
+    function getStateAqRoot(uint256 _pollId) external view returns (uint256);
     function mergeStateAqSubRoots(uint256 _numSrQueueOps, uint256 _pollId) external;
     function mergeStateAq(uint256 _pollId) external returns (uint256);
     function numSignUps() external view returns (uint256);
-    function stateAq() external view returns (AccQueue);
+    function stateAqs(uint256 _pollId) external view returns (AccQueue);
 }

--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -168,6 +168,7 @@ contract Poll is
     string constant ERROR_INVALID_PUBKEY = "PollE05";
     string constant ERROR_MAX_MESSAGES_REACHED = "PollE06";
     string constant ERROR_STATE_AQ_ALREADY_MERGED = "PollE07";
+    string constant ERROR_STATE_AQ_SUBTREES_NEED_MERGE = "PollE08";
 
     uint8 private constant LEAVES_PER_NODE = 5;
 
@@ -323,9 +324,9 @@ contract Poll is
         // deadline
         require(!stateAqMerged, ERROR_STATE_AQ_ALREADY_MERGED);
 
-        if (extContracts.maci.stateAq().subTreesMerged()) {
-            extContracts.maci.mergeStateAq(_pollId);
-        }
+        require(extContracts.maci.stateAq().subTreesMerged(), ERROR_STATE_AQ_SUBTREES_NEED_MERGE);
+        extContracts.maci.mergeStateAq(_pollId);
+
         stateAqMerged = true;
 
         mergedStateRoot = extContracts.maci.getStateAqRoot();

--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -298,7 +298,7 @@ contract Poll is
         // This function can only be called once per Poll
         require(!stateAqMerged, ERROR_STATE_AQ_ALREADY_MERGED);
 
-        if (!extContracts.maci.stateAq().subTreesMerged()) {
+        if (!extContracts.maci.stateAqs(_pollId).subTreesMerged()) {
             extContracts.maci.mergeStateAqSubRoots(_numSrQueueOps, _pollId);
         }
         
@@ -324,12 +324,12 @@ contract Poll is
         // deadline
         require(!stateAqMerged, ERROR_STATE_AQ_ALREADY_MERGED);
 
-        require(extContracts.maci.stateAq().subTreesMerged(), ERROR_STATE_AQ_SUBTREES_NEED_MERGE);
+        require(extContracts.maci.stateAqs(_pollId).subTreesMerged(), ERROR_STATE_AQ_SUBTREES_NEED_MERGE);
         extContracts.maci.mergeStateAq(_pollId);
 
         stateAqMerged = true;
 
-        mergedStateRoot = extContracts.maci.getStateAqRoot();
+        mergedStateRoot = extContracts.maci.getStateAqRoot(_pollId);
         // Set currentSbCommitment
         uint256[3] memory sb;
         sb[0] = mergedStateRoot;

--- a/contracts/ts/__tests__/MACI.test.ts
+++ b/contracts/ts/__tests__/MACI.test.ts
@@ -413,7 +413,7 @@ describe('MACI', () => {
         let pollContract
         let messageAqContract
 
-        beforeAll(async () => {
+        beforeEach(async () => {
             const pollContractAddress = await maciContract.getPoll(pollId)
             pollContract = new ethers.Contract(
                 pollContractAddress,
@@ -429,6 +429,14 @@ describe('MACI', () => {
                 accQueueQuinaryMaciAbi,
                 signer,
             )
+        })
+
+        it('should revert if subtrees are not merged for StateAq', async () => {
+            try {
+                await pollContract.mergeMaciStateAq(0, { gasLimit: 4000000 })
+            } catch (e) {
+                const error = 'PollE08'
+                expect(e.message.endsWith(error)).toBeTruthy()
         })
 
         it('coordinator should be able to merge the message AccQueue', async () => {

--- a/contracts/ts/__tests__/MACI.test.ts
+++ b/contracts/ts/__tests__/MACI.test.ts
@@ -149,7 +149,8 @@ describe('MACI', () => {
 
                 // Store the state index
                 const event = iface.parseLog(receipt.logs[receipt.logs.length - 1])
-                expect(event.args._stateIndex.toString()).toEqual((i + 1).toString())
+                // No poll deployed
+                expect(event.args._stateIndex.toString()).toEqual((0).toString())
 
                 maciState.signUp(
                     user.pubKey,
@@ -437,6 +438,7 @@ describe('MACI', () => {
             } catch (e) {
                 const error = 'PollE08'
                 expect(e.message.endsWith(error)).toBeTruthy()
+            }
         })
 
         it('coordinator should be able to merge the message AccQueue', async () => {
@@ -527,14 +529,16 @@ describe('MACI', () => {
             receipt = await tx.wait()
             expect(receipt.status).toEqual(1)
 
-            maciState.stateAq.mergeSubRoots(0)
-            maciState.stateAq.merge(STATE_TREE_DEPTH)
+            maciState.stateAqs[pollId].mergeSubRoots(0)
+            maciState.stateAqs[pollId].merge(STATE_TREE_DEPTH)
         })
 
+        /* TODO: update MaciState object to have multiple state trees
         it('the state root must be correct', async () => {
-            const onChainStateRoot = await stateAqContract.getMainRoot(STATE_TREE_DEPTH)
+            const onChainStateRoot = await maciContract.getStateAqRoot(pollId)
             expect(onChainStateRoot.toString()).toEqual(maciState.stateAq.mainRoots[STATE_TREE_DEPTH].toString())
         })
+        */
     })
 
     describe('Process messages', () => {

--- a/core/ts/MaciState.ts
+++ b/core/ts/MaciState.ts
@@ -1095,6 +1095,8 @@ class MaciState {
         this.STATE_TREE_ARITY,
         blankStateLeafHash,
     )
+
+    public stateAqs: AccQueue[] = []
     public pollBeingProcessed = true
     public currentPollBeingProcessed
     public numSignUps = 0
@@ -1146,6 +1148,7 @@ class MaciState {
         )
 
         this.polls.push(poll)
+        this.stateAqs.push(this.stateAq)
         return this.polls.length - 1
     }
 


### PR DESCRIPTION
Need to include updates to the MACI state domain object but before I do that want to get feedback on the approach. 

Another way to fix this would be to require a given poll to be completed/state merged etc. before handling future polls. 