### PR TITLE
use uint16 for treeArity in PollFactory.deploy

### DIFF
--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -60,7 +60,7 @@ contract PollFactory is Params, IPubKey, IMessage, Ownable, Hasher, PollDeployme
         IMACI _maci,
         address _pollOwner
     ) public onlyOwner returns (Poll) {
-        uint8 treeArity = 5;
+        uint16 treeArity = 5;
 
         // Validate _maxValues
         // NOTE: these checks may not be necessary. Removing them will save

--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -60,7 +60,7 @@ contract PollFactory is Params, IPubKey, IMessage, Ownable, Hasher, PollDeployme
         IMACI _maci,
         address _pollOwner
     ) public onlyOwner returns (Poll) {
-        uint16 treeArity = 5;
+        uint256 treeArity = 5;
 
         // Validate _maxValues
         // NOTE: these checks may not be necessary. Removing them will save
@@ -71,10 +71,10 @@ contract PollFactory is Params, IPubKey, IMessage, Ownable, Hasher, PollDeployme
         // of the inputs (aka packedVal)
 
         require(
-            _maxValues.maxMessages <= treeArity ** _treeDepths.messageTreeDepth &&
+            _maxValues.maxMessages <= treeArity ** uint256(_treeDepths.messageTreeDepth) &&
             _maxValues.maxMessages >= _batchSizes.messageBatchSize &&
             _maxValues.maxMessages % _batchSizes.messageBatchSize == 0 &&
-            _maxValues.maxVoteOptions <= treeArity ** _treeDepths.voteOptionTreeDepth &&
+            _maxValues.maxVoteOptions <= treeArity ** uint256(_treeDepths.voteOptionTreeDepth) &&
             _maxValues.maxVoteOptions < (2 ** 50),
             "PollFactory: invalid _maxValues"
         );


### PR DESCRIPTION
In maci/contracts/contracts/Poll.sol,

since the type of `treeArity` is `uint8`,
```
        uint8 treeArity = 5;   // line 63
```
in 
```
        require(   // line 73
            _maxValues.maxMessages <= treeArity ** _treeDepths.messageTreeDepth &&
            ...
```
`treeArity ** _treeDepths.messageTreeDepth` seems to overflow when `_treeDepths.messageTreeDepth` is greater than `3`, i.e. `5^3 = 125` but `5^4 = 625` which is greater than `256`, and that makes the require statement fail.

The type of `treeArity` should be a type that can store larger values without overflow.