### PR TITLE
Fix proof generation for subsequential polls

### DIFF
--- a/cli/testMultiplePoll.sh
+++ b/cli/testMultiplePoll.sh
@@ -1,0 +1,87 @@
+# one signup and one valid message
+node build/index.js deployVkRegistry  && \
+node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 \
+    -p ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey \
+    -t ./zkeys/TallyVotes_10-1-2.test.0.zkey \
+    -k 0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0 && \
+node build/index.js create \
+    -r 0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0 && \
+node ./build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
+    -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
+    -t 20 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2 && \
+node ./build/index.js signup \
+    -p macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391 \
+    -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a && \
+
+node build/index.js publish \
+    -p macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391 \
+    -sk macisk.fd7aa614ec4a82716ffc219c24fd7e7b52a2b63b5afb17e81c22fe21515539c \
+    -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
+    -i 1 -v 0 -w 9 -n 1 -o 0
+
+node build/index.js timeTravel -s 30 && \
+node build/index.js mergeMessages -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0 && \
+node build/index.js mergeSignups -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0 && \
+rm -f tally.json proofs.json && \
+
+node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
+    -sk macisk.49953af3585856f539d194b46c82f4ed54ec508fb9b882940cbe68bbc57e59e \
+    -o 0 \
+    -r ~/rapidsnark/build/prover \
+    -wp ./zkeys/ProcessMessages_10-2-1-2.test \
+    -wt ./zkeys/TallyVotes_10-1-2.test \
+    -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey \
+    -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey \
+    -t tally.json \
+    -f proofs.json
+
+node build/index.js proveOnChain \
+    -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
+    -o 0 \
+    -q 0xEcFcaB0A285d3380E488A39B4BB21e777f8A4EaC \
+    -f proofs.json
+
+node build/index.js verify \
+    -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
+    -o 0 \
+    -t tally.json \
+    -q 0xEcFcaB0A285d3380E488A39B4BB21e777f8A4EaC
+
+node ./build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
+    -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
+    -t 120 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2 && \
+
+node build/index.js publish \
+    -p macipk.3e7bb2d7f0a1b7e980f1b6f363d1e3b7a12b9ae354c2cd60a9cfa9fd12917391 \
+    -sk macisk.fd7aa614ec4a82716ffc219c24fd7e7b52a2b63b5afb17e81c22fe21515539c \
+    -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
+    -i 1 -v 0 -w 7 -n 1 -o 1
+
+node build/index.js timeTravel -s 140 && \
+node build/index.js mergeMessages -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 1 && \
+
+rm -f tally.json proofs.json && \
+node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
+    -sk macisk.49953af3585856f539d194b46c82f4ed54ec508fb9b882940cbe68bbc57e59e \
+    -o 1 \
+    -r ~/rapidsnark/build/prover \
+    -wp ./zkeys/ProcessMessages_10-2-1-2.test \
+    -wt ./zkeys/TallyVotes_10-1-2.test \
+    -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey \
+    -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey \
+    -t tally.json \
+    -f proofs.json
+
+
+node build/index.js proveOnChain \
+    -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
+    -o 1 \
+    -q 0x8ACEe021a27779d8E98B9650722676B850b25E11 \
+    -f proofs.json
+
+node build/index.js verify \
+    -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
+    -o 1 \
+    -t tally.json \
+    -q 0x8ACEe021a27779d8E98B9650722676B850b25E11
+

--- a/cli/testMultiplePoll.sh
+++ b/cli/testMultiplePoll.sh
@@ -1,4 +1,4 @@
-# one signup and one valid message
+# one signup and one valid message for multiple polls
 node build/index.js deployVkRegistry  && \
 node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 \
     -p ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey \
@@ -59,6 +59,7 @@ node build/index.js publish \
 
 node build/index.js timeTravel -s 140 && \
 node build/index.js mergeMessages -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 1 && \
+node build/index.js mergeSignups -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 1 && \
 
 rm -f tally.json proofs.json && \
 node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
@@ -71,7 +72,6 @@ node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey \
     -t tally.json \
     -f proofs.json
-
 
 node build/index.js proveOnChain \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \

--- a/cli/ts/genProofs.ts
+++ b/cli/ts/genProofs.ts
@@ -249,8 +249,9 @@ const genProofs = async (args: any) => {
         signer,
     )
 
-    // Check that the state and message trees have been merged
-    if (!(await pollContract.stateAqMerged())) {
+
+    // Check that the state and message trees have been merged for at least the first poll
+    if (!(await pollContract.stateAqMerged()) && pollId == 0) {
         console.error(
             'Error: the state tree has not been merged yet. ' +
             'Please use the mergeSignups subcommmand to do so.'

--- a/cli/ts/mergeMessages.ts
+++ b/cli/ts/mergeMessages.ts
@@ -70,7 +70,7 @@ const mergeMessages = async (args: any) => {
         return 1
     }
 
-    const pollId = args.poll_id
+    const pollId = Number(args.poll_id)
 
     if (pollId < 0) {
         console.error('Error: the Poll ID should be a positive integer.')

--- a/cli/ts/mergeSignups.ts
+++ b/cli/ts/mergeSignups.ts
@@ -148,7 +148,7 @@ const mergeSignups = async (args: any) => {
     const stateTreeDepth = Number(await maciContractEthers.stateTreeDepth())
     const mainRoot = (await accQueueContract.getMainRoot(stateTreeDepth.toString())).toString()
 
-    if (mainRoot === '0') {
+    if (mainRoot === '0' || pollId > 0) {
         console.log('Merging subroots to a main state root...')
         const tx = await pollContract.mergeMaciStateAq(pollId.toString())
         const receipt = await tx.wait()

--- a/contracts/contracts/MACI.sol
+++ b/contracts/contracts/MACI.sol
@@ -290,6 +290,13 @@ contract MACI is IMACI, DomainObjs, Params, SnarkCommon, Ownable {
     ) public afterInit {
         uint256 pollId = nextPollId;
 
+        if (pollId != 0) {
+            require(
+                polls[pollId].isAfterDeadline() && stateAq.treeMerged() == true,
+                "MACI: previous poll must be completed before using a new instance"
+            );
+        }
+
         // The message batch size and the tally batch size
         BatchSizes memory batchSizes = BatchSizes(
             MESSAGE_TREE_ARITY ** uint8(_treeDepths.messageTreeSubDepth),

--- a/contracts/contracts/MACI.sol
+++ b/contracts/contracts/MACI.sol
@@ -290,9 +290,9 @@ contract MACI is IMACI, DomainObjs, Params, SnarkCommon, Ownable {
     ) public afterInit {
         uint256 pollId = nextPollId;
 
-        if (pollId != 0) {
+        if (pollId > 0) {
             require(
-                polls[pollId].isAfterDeadline() && stateAq.treeMerged() == true,
+                stateAq.treeMerged() == true,
                 "MACI: previous poll must be completed before using a new instance"
             );
         }

--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -148,10 +148,10 @@ contract Poll is
     // the case that none of the messages are valid.
     uint256 public currentSbCommitment;
 
-    uint256 internal numSignUps;
     uint256 internal numMessages;
 
     function numSignUpsAndMessages() public view returns (uint256, uint256) {
+        uint numSignUps = extContracts.maci.numSignUps();
         return (numSignUps, numMessages);
     }
 
@@ -299,10 +299,6 @@ contract Poll is
 
         if (!extContracts.maci.stateAq().subTreesMerged()) {
             extContracts.maci.mergeStateAqSubRoots(_numSrQueueOps, _pollId);
-        }
-        
-        if (numSignUps == 0) {
-            numSignUps = extContracts.maci.numSignUps();
         }
 
         emit MergeMaciStateAqSubRoots(_numSrQueueOps);

--- a/contracts/contracts/Poll.sol
+++ b/contracts/contracts/Poll.sol
@@ -434,7 +434,6 @@ contract Poll is
         uint256 _voteOptionIndex,
         uint256 _tallyResult,
         uint256[][] memory _tallyResultProof,
-        uint256 _tallyResultSalt,
         uint256 _spentVoiceCreditsHash,
         uint256 _perVOSpentVoiceCreditsHash,
         uint256 _tallyCommitment

--- a/contracts/contracts/trees/AccQueue.sol
+++ b/contracts/contracts/trees/AccQueue.sol
@@ -68,6 +68,9 @@ abstract contract AccQueue is Ownable, Hasher {
     // Whether the subtrees have been merged
     bool public subTreesMerged;
 
+    // Whether entire merkle tree has been merged
+    bool public treeMerged;
+
     // The root of the shortest possible tree which fits all current subtree
     // roots
     uint256 internal smallSRTroot;
@@ -423,6 +426,7 @@ abstract contract AccQueue is Ownable, Hasher {
         // If the depth is the same as the SRT depth, just use the SRT root
         if (_depth == srtDepth) {
             mainRoots[_depth] = smallSRTroot;
+            treeMerged = true;
             return smallSRTroot;
         } else {
 
@@ -451,6 +455,7 @@ abstract contract AccQueue is Ownable, Hasher {
             }
 
             mainRoots[_depth] = root;
+            treeMerged = true;
             return root;
         }
     }

--- a/contracts/ts/genMaciState.ts
+++ b/contracts/ts/genMaciState.ts
@@ -389,7 +389,9 @@ const genMaciStateFromContract = async (
                 action.data.numSrQueueOps,
             )
         } else if (action['type'] === 'MergeMaciStateAq') {
-            maciState.stateAq.merge(stateTreeDepth)
+            if (pollId == 0) {
+                maciState.stateAq.merge(stateTreeDepth)
+            }
         } else if (action['type'] === 'MergeMessageAqSubRoots') {
             maciState.polls[pollId].messageAq.mergeSubRoots(
                 action.data.numSrQueueOps,


### PR DESCRIPTION
Instead of allowing concurrent polls where users must signup for each poll, this PR aims to allow on chain proof verification for a multiple poll instances with the same set of users.

Testing run `cli/testMultiplePoll.sh` 