### PR TITLE
Add check for poseidon libs in constructor

### DIFF
--- a/contracts/contracts/MACI.sol
+++ b/contracts/contracts/MACI.sol
@@ -122,6 +122,9 @@ contract MACI is IMACI, DomainObjs, Params, SnarkCommon, Ownable {
         initialVoiceCreditProxy = _initialVoiceCreditProxy;
 
         signUpTimestamp = block.timestamp;
+
+        // Verify linked poseidon libraries
+        require(hash2([uint256(1),uint256(1)]) != 0, "MACI: poseidon hash libraries not linked");
     }
 
     /*


### PR DESCRIPTION
Unit tests are a bit of a challenge since hardhat will throw an error if you try deploying a contract factory without a properly linked library