### PR TITLE
Save each proof in its own file, rather than one big proofs.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 circuits/params/*
+cli/proofs
 cli/proofs.json
 cli/zkeys
 *.zkey

--- a/cli/test.sh
+++ b/cli/test.sh
@@ -22,7 +22,7 @@ node build/index.js publish \
 node build/index.js timeTravel -s 30 && \
 node build/index.js mergeMessages -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0 && \
 node build/index.js mergeSignups -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0 && \
-rm -f tally.json proofs.json && \
+rm -rf proofs tally.json && \
 node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -sk macisk.49953af3585856f539d194b46c82f4ed54ec508fb9b882940cbe68bbc57e59e \
     -o 0 \
@@ -32,13 +32,13 @@ node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey \
     -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey \
     -t tally.json \
-    -f proofs.json
+    -f proofs/
 
 node build/index.js proveOnChain \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -o 0 \
     -q 0xEcFcaB0A285d3380E488A39B4BB21e777f8A4EaC \
-    -f proofs.json
+    -f proofs/
 
 node build/index.js verify \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \

--- a/cli/test2.sh
+++ b/cli/test2.sh
@@ -29,15 +29,15 @@ node build/index.js timeTravel -s 30
 node build/index.js mergeSignups -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0
 node build/index.js mergeMessages -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0
 
-rm -f proofs.json tally.json
+rm -rf proofs/ tally.json
 
-node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -sk macisk.1b421413d3e82a3e955b591b2d8f943032537e7a8634223710c6c0f0094a058b -o 0 -r ~/rapidsnark/build/prover -wp ./zkeys/ProcessMessages_10-2-1-2.test -wt ./zkeys/TallyVotes_10-1-2.test -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey -t tally.json -f proofs.json
+node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -sk macisk.1b421413d3e82a3e955b591b2d8f943032537e7a8634223710c6c0f0094a058b -o 0 -r ~/rapidsnark/build/prover -wp ./zkeys/ProcessMessages_10-2-1-2.test -wt ./zkeys/TallyVotes_10-1-2.test -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey -t tally.json -f proofs/
 
 node build/index.js proveOnChain \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -o 0 \
     -q 0xEcFcaB0A285d3380E488A39B4BB21e777f8A4EaC \
-    -f proofs.json
+    -f proofs/
 
 node build/index.js verify \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \

--- a/cli/test3.sh
+++ b/cli/test3.sh
@@ -21,15 +21,15 @@ node build/index.js timeTravel -s 30
 node build/index.js mergeSignups -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0
 node build/index.js mergeMessages -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0
 
-rm -f proofs.json tally.json
+rm -rf proofs/ tally.json
 
-node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -sk macisk.1b421413d3e82a3e955b591b2d8f943032537e7a8634223710c6c0f0094a058b -o 0 -r ~/rapidsnark/build/prover -wp ./zkeys/ProcessMessages_10-2-1-2.test -wt ./zkeys/TallyVotes_10-1-2.test -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey -t tally.json -f proofs.json
+node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -sk macisk.1b421413d3e82a3e955b591b2d8f943032537e7a8634223710c6c0f0094a058b -o 0 -r ~/rapidsnark/build/prover -wp ./zkeys/ProcessMessages_10-2-1-2.test -wt ./zkeys/TallyVotes_10-1-2.test -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey -t tally.json -f proofs/
 
 node build/index.js proveOnChain \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -o 0 \
     -q 0xEcFcaB0A285d3380E488A39B4BB21e777f8A4EaC \
-    -f proofs.json
+    -f proofs/
 
 node build/index.js verify \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \

--- a/cli/test4.sh
+++ b/cli/test4.sh
@@ -5,7 +5,7 @@ node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 -p ./zkeys/Proces
 
 node build/index.js create -r 0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0
 
-node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 20 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2
+node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 60 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2
 
 node ../cli/build/index.js signup -p macipk.b1672ac299bb443f89bca9aeface6edfa5319a4b2135588ca1bfb352d7d09d1e -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a
 node ../cli/build/index.js signup -p macipk.b1672ac299bb443f89bca9aeface6edfa5319a4b2135588ca1bfb352d7d09d1e -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a
@@ -28,20 +28,20 @@ node build/index.js publish -sk macisk.292ee6e47ff0225c12a2875408be223ad6653f73e
 node build/index.js publish -sk macisk.292ee6e47ff0225c12a2875408be223ad6653f73e4719496bad98838d3d4d4aa -p macipk.1f968d8a40d8f7ffde4fa70b7c24170be1bb258948c50f85c6bdfe380ca25f83 -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -i 1 -v 0 -w 1 -n 1 -o 0                 
 node build/index.js publish -sk macisk.292ee6e47ff0225c12a2875408be223ad6653f73e4719496bad98838d3d4d4aa -p macipk.1f968d8a40d8f7ffde4fa70b7c24170be1bb258948c50f85c6bdfe380ca25f83 -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -i 1 -v 0 -w 1 -n 1 -o 0                 
 
-node build/index.js timeTravel -s 30
+node build/index.js timeTravel -s 60
 
 node build/index.js mergeSignups -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0
 node build/index.js mergeMessages -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0
 
-rm -f proofs.json tally.json
+rm -rf proofs tally.json
 
-node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -sk macisk.1b421413d3e82a3e955b591b2d8f943032537e7a8634223710c6c0f0094a058b -o 0 -r ~/rapidsnark/build/prover -wp ./zkeys/ProcessMessages_10-2-1-2.test -wt ./zkeys/TallyVotes_10-1-2.test -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey -t tally.json -f proofs.json
+node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -sk macisk.1b421413d3e82a3e955b591b2d8f943032537e7a8634223710c6c0f0094a058b -o 0 -r ~/rapidsnark/build/prover -wp ./zkeys/ProcessMessages_10-2-1-2.test -wt ./zkeys/TallyVotes_10-1-2.test -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey -t tally.json -f proofs/
 
 node build/index.js proveOnChain \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -o 0 \
     -q 0xEcFcaB0A285d3380E488A39B4BB21e777f8A4EaC \
-    -f proofs.json
+    -f proofs/
 
 node build/index.js verify \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \

--- a/cli/test5.sh
+++ b/cli/test5.sh
@@ -5,7 +5,7 @@ node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 -p ./zkeys/Proces
 
 node build/index.js create -r 0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0
 
-node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 20 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2
+node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 60 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2
 
 node ./build/index.js signup -p macipk.4d8797043f3f54b9090cb7ddbb79a618297e3f94011e2d2b206dc05a52722498 -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a
 
@@ -23,20 +23,20 @@ node ./build/index.js publish -sk macisk.10da10e0e9a5cc1a7a9505868940ca7d493eef6
 
 node ./build/index.js publish -sk macisk.58dbcf4ee007b14856192fb336bba171fcb5a630f4954d49e49ac1d95af360e -p macipk.3a88d434c5c5a3ca15b849c8542087026f7890f73451429d57e75f4a3c9e7581 -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -i 4 -v 0 -w 1 -n 1 -o 0
 
-node build/index.js timeTravel -s 30
+node build/index.js timeTravel -s 60
 
 node build/index.js mergeSignups -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0
 node build/index.js mergeMessages -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0
 
-rm -f proofs.json tally.json
+rm -rf proofs tally.json
 
-node --inspect-brk build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -sk macisk.1b421413d3e82a3e955b591b2d8f943032537e7a8634223710c6c0f0094a058b -o 0 -r ~/rapidsnark/build/prover -wp ./zkeys/ProcessMessages_10-2-1-2.test -wt ./zkeys/TallyVotes_10-1-2.test -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey -t tally.json -f proofs.json
+node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -sk macisk.1b421413d3e82a3e955b591b2d8f943032537e7a8634223710c6c0f0094a058b -o 0 -r ~/rapidsnark/build/prover -wp ./zkeys/ProcessMessages_10-2-1-2.test -wt ./zkeys/TallyVotes_10-1-2.test -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey -t tally.json -f proofs/
 
 node build/index.js proveOnChain \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -o 0 \
     -q 0xEcFcaB0A285d3380E488A39B4BB21e777f8A4EaC \
-    -f proofs.json
+    -f proofs/
 
 node build/index.js verify \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \

--- a/cli/test6.sh
+++ b/cli/test6.sh
@@ -5,7 +5,7 @@ node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 -p ./zkeys/Proces
 
 node build/index.js create -r 0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0
 
-node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 20 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2
+node build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -pk macipk.81722e96a9296698f90cbd895786a0088d3ab5c36b0176f2c65b5415de7b5b2f -t 60 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2
 
 node ./build/index.js signup -p macipk.014cc8ef5a0022da608efab55e891417be0a474ba70b912dc6c2e6acea1a1499 -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a
 
@@ -27,23 +27,23 @@ node build/index.js publish -sk macisk.28c1c7bb2b081da17e82075264ec20d6a022fbd54
 
 node build/index.js publish -sk macisk.1ee8e41c2b79b1a79659ccde72ed0e24b1ad97c7c550aaf8261defb46eb78343 -p macipk.f7dc5da79e53d8e634f58506be11bc593f4d731834cbffc0fadff319215f8aad -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -i 5 -v 0 -w 1 -n 1 -o 0
 
-node build/index.js timeTravel -s 30
+node build/index.js timeTravel -s 60
 
 node build/index.js mergeSignups -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0
 node build/index.js mergeMessages -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0
 
-rm -f proofs.json tally.json
+rm -rf proofs tally.json
 
-node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -sk macisk.1b421413d3e82a3e955b591b2d8f943032537e7a8634223710c6c0f0094a058b -o 0 -r ~/rapidsnark/build/prover -wp ./zkeys/ProcessMessages_10-2-1-2.test -wt ./zkeys/TallyVotes_10-1-2.test -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey -t tally.json -f proofs.json
+node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -sk macisk.1b421413d3e82a3e955b591b2d8f943032537e7a8634223710c6c0f0094a058b -o 0 -r ~/rapidsnark/build/prover -wp ./zkeys/ProcessMessages_10-2-1-2.test -wt ./zkeys/TallyVotes_10-1-2.test -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey -t tally.json -f proofs/
 
-#node build/index.js proveOnChain \
-    #-x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
-    #-o 0 \
-    #-q 0xEcFcaB0A285d3380E488A39B4BB21e777f8A4EaC \
-    #-f proofs.json
+node build/index.js proveOnChain \
+    -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
+    -o 0 \
+    -q 0xEcFcaB0A285d3380E488A39B4BB21e777f8A4EaC \
+    -f proofs/
 
-#node build/index.js verify \
-    #-x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
-    #-o 0 \
-    #-t tally.json \
-    #-q 0xEcFcaB0A285d3380E488A39B4BB21e777f8A4EaC
+node build/index.js verify \
+    -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
+    -o 0 \
+    -t tally.json \
+    -q 0xEcFcaB0A285d3380E488A39B4BB21e777f8A4EaC

--- a/cli/testKeyChange.sh
+++ b/cli/testKeyChange.sh
@@ -11,7 +11,7 @@ node build/index.js create \
     -r 0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0
     
 node ./build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
-    -pk macipk.495140c99cbc090c74363d5e3f32705a92a9e1df8e5ebe2fd6831de9c813f01f \
+    -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
     -t 20 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2
 
 node ./build/index.js signup \
@@ -49,7 +49,7 @@ node build/index.js publish \
 node build/index.js timeTravel -s 30 && \
 node build/index.js mergeMessages -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0 && \
 node build/index.js mergeSignups -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0 && \
-rm -f tally.json proofs.json && \
+rm -rf tally.json proofs/ && \
 node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -sk macisk.49953af3585856f539d194b46c82f4ed54ec508fb9b882940cbe68bbc57e59e \
     -o 0 \
@@ -59,13 +59,13 @@ node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey \
     -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey \
     -t tally.json \
-    -f proofs.json
+    -f proofs/
 
 node build/index.js proveOnChain \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -o 0 \
     -q 0xEcFcaB0A285d3380E488A39B4BB21e777f8A4EaC \
-    -f proofs.json
+    -f proofs/
 
 node build/index.js verify \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \

--- a/cli/testMultiBatches.sh
+++ b/cli/testMultiBatches.sh
@@ -6,7 +6,7 @@ node build/index.js setVerifyingKeys -s 10 -i 1 -m 2 -v 2 -b 1 \
 node build/index.js create \
     -r 0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0 && \
 node ./build/index.js deployPoll -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
-    -pk macipk.495140c99cbc090c74363d5e3f32705a92a9e1df8e5ebe2fd6831de9c813f01f \
+    -pk macipk.c974f4f168b79727ac98bfd53a65ea0b4e45dc2552fe73df9f8b51ebb0930330 \
     -t 120 -g 25 -mv 25 -i 1 -m 2 -b 1 -v 2 
 
 # Sign up 6 times
@@ -69,7 +69,7 @@ node build/index.js publish \
 node build/index.js timeTravel -s 120 && \
 node build/index.js mergeMessages -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0 && \
 node build/index.js mergeSignups -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0 && \
-rm -f tally.json proofs.json && \
+rm -rf tally.json proofs && \
 node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -sk macisk.49953af3585856f539d194b46c82f4ed54ec508fb9b882940cbe68bbc57e59e \
     -o 0 \
@@ -79,13 +79,13 @@ node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey \
     -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey \
     -t tally.json \
-    -f proofs.json
+    -f proofs/
 
 node build/index.js proveOnChain \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -o 0 \
     -q 0xEcFcaB0A285d3380E488A39B4BB21e777f8A4EaC \
-    -f proofs.json
+    -f proofs/
 
 node build/index.js verify \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \

--- a/cli/testMultiplePoll.sh
+++ b/cli/testMultiplePoll.sh
@@ -22,7 +22,7 @@ node build/index.js publish \
 node build/index.js timeTravel -s 30 && \
 node build/index.js mergeMessages -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0 && \
 node build/index.js mergeSignups -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 0 && \
-rm -f tally.json proofs.json && \
+rm -rf tally.json proofs && \
 
 node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -sk macisk.49953af3585856f539d194b46c82f4ed54ec508fb9b882940cbe68bbc57e59e \
@@ -33,13 +33,13 @@ node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey \
     -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey \
     -t tally.json \
-    -f proofs.json
+    -f proofs/
 
 node build/index.js proveOnChain \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -o 0 \
     -q 0xEcFcaB0A285d3380E488A39B4BB21e777f8A4EaC \
-    -f proofs.json
+    -f proofs/
 
 node build/index.js verify \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
@@ -61,7 +61,7 @@ node build/index.js timeTravel -s 140 && \
 node build/index.js mergeMessages -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 1 && \
 node build/index.js mergeSignups -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a -o 1 && \
 
-rm -f tally.json proofs.json && \
+rm -rf tally.json proofs && \
 node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -sk macisk.49953af3585856f539d194b46c82f4ed54ec508fb9b882940cbe68bbc57e59e \
     -o 1 \
@@ -71,13 +71,13 @@ node build/index.js genProofs -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey \
     -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey \
     -t tally.json \
-    -f proofs.json
+    -f proofs/
 
 node build/index.js proveOnChain \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \
     -o 1 \
     -q 0x8ACEe021a27779d8E98B9650722676B850b25E11 \
-    -f proofs.json
+    -f proofs/
 
 node build/index.js verify \
     -x 0xf204a4Ef082f5c04bB89F7D5E6568B796096735a \

--- a/integrationTests/ts/__tests__/suites.ts
+++ b/integrationTests/ts/__tests__/suites.ts
@@ -258,7 +258,7 @@ const executeSuite = async (data: any, expect: any) => {
     }
     console.log(e.stdout)
 
-    const removeOldProofs = `rm -f tally.json proofs.json`
+    const removeOldProofs = `rm -f tally.json proofs`
     e = exec(removeOldProofs)
 
     const genProofsCommand = `node build/index.js genProofs` +
@@ -271,7 +271,7 @@ const executeSuite = async (data: any, expect: any) => {
         ` -zp ./zkeys/ProcessMessages_10-2-1-2.test.0.zkey` +
         ` -zt ./zkeys/TallyVotes_10-1-2.test.0.zkey` +
         ` -t tally.json` +
-        ` -f proofs.json`
+        ` -f proofs/`
 
     console.log(genProofsCommand)
     e = exec(genProofsCommand)
@@ -297,7 +297,7 @@ const executeSuite = async (data: any, expect: any) => {
         ` -x ${maciAddress}` +
         ` -o ${pollId}` +
         ` -q ${pptAddress}` +
-        ` -f proofs.json`
+        ` -f proofs/`
 
     console.log(proveOnChainCommand)
     e = exec(proveOnChainCommand)

--- a/integrationTests/ts/__tests__/suites.ts
+++ b/integrationTests/ts/__tests__/suites.ts
@@ -258,7 +258,7 @@ const executeSuite = async (data: any, expect: any) => {
     }
     console.log(e.stdout)
 
-    const removeOldProofs = `rm -f tally.json proofs`
+    const removeOldProofs = `rm -rf tally.json proofs`
     e = exec(removeOldProofs)
 
     const genProofsCommand = `node build/index.js genProofs` +


### PR DESCRIPTION
When there are many messages, there will be many batches of proofs to store. Previously, MACI saved them in a single JSON file, but clrfund round 8 taught us that if this file gets too large, we won't be able to easily parse it due to the string length limit in Nodejs.

As such, this PR makes genProofs save each proof in its own file in a user-specified proofs directory.

Addresses https://github.com/appliedzkp/maci/issues/316