### PR TITLE
Use of ubuntu 21.04 in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,21 @@
-FROM node:15.8.0-buster
+FROM ubuntu:21.04
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN apt-get update -qq --fix-missing && \
     apt-get install -qq -y curl build-essential libssl-dev libgmp-dev \
                        libsodium-dev nlohmann-json3-dev git nasm
+
+# Install Node & NPM via nvm
+ENV NODE_VERSION=15.8.0
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+ENV NVM_DIR=/root/.nvm
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+RUN node --version
+RUN npm --version
 
 # Install zkutil
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y


### PR DESCRIPTION
Hey, I've been testing the `genProofs` and `proveOnChain` scripts using the Docker image with the params files that we have in clrfund from the trusted setup https://gateway.pinata.cloud/ipfs/QmWSxPBNYDtsK23KwYdMtcDaJg3gWS3LBsqMnENrVG6nmc.

The scripts failed with the debian `node:15.8.0-buster` image we are using atm. More context of this error here: https://github.com/clrfund/monorepo/issues/417

@daodesigner told me to test them using ubuntu 21.04 since those params files were built using that OS and indeed, they worked fine.

I've created this PR to use that version which seems to be using a newer version of libc. And I kept the same node version we are using (`15.8.0`).

Note: I'm targeting the `master` branch...let me know in case you want me to change that.

Thanks!