### PR TITLE
Add CI workflows to test subpackages

### DIFF
--- a/.github/workflows/circuit-build.yml
+++ b/.github/workflows/circuit-build.yml
@@ -1,0 +1,63 @@
+name: Circuit
+
+on:
+  push:
+    branches: [ v1 ]
+  pull_request:
+    branches: [ v1 ]
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [14, 16]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes \
+            build-essential \
+            libgmp-dev \
+            libsodium-dev \
+            nasm \
+            nlohmann-json3-dev \
+            git
+
+      - name: Build
+        run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
+          npm install
+          npm run build
+        working-directory: circuits
+
+      - name: Download circom Binary v2.0.3
+        run: |
+          mkdir -p /home/runner/work/maci/.local/bin
+          wget -O /home/runner/work/maci/.local/bin/circom https://maci-devops-zkeys.s3.ap-northeast-2.amazonaws.com/circom-linux-amd64-v2.0.3
+          chmod +x /home/runner/work/maci/.local/bin/circom
+
+      - name: Run circom-helper
+        run: |
+          nohup npm run circom-helper &
+
+          # Wait until circom-helper listen to port 9001
+          while [[ "$(lsof -i :9001)" -eq '0' ]]; do sleep 1; done
+        working-directory: circuits
+      
+      - name: Test
+        run: npm run test
+        working-directory: circuits

--- a/.github/workflows/circuit-build.yml
+++ b/.github/workflows/circuit-build.yml
@@ -52,6 +52,12 @@ jobs:
 
       - name: Run circom-helper
         run: |
+          
+          # Prevent error `Error: ENOENT: no such file or directory, scandir '/home/ubuntu/maci/circuits/circom/prod/'`
+          # TODO: Add `./circom/prod/` to `circuitDirs` of `circuits/circomHelperConfig.json` when
+          #      `circuits/scripts/buildCustomSnarks.sh` script executed
+          mkdir circom/prod
+          
           nohup npm run circom-helper &
 
           # Wait until circom-helper listen to port 9001

--- a/.github/workflows/circuit-build.yml
+++ b/.github/workflows/circuit-build.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -40,6 +40,7 @@ jobs:
       - name: Build
         run: |
           git config --global url."https://github.com/".insteadOf git://github.com/
+          npm install --global npm
           npm install
           npm run build
         working-directory: circuits

--- a/.github/workflows/contracts-build.yml
+++ b/.github/workflows/contracts-build.yml
@@ -25,10 +25,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-          
+
       - name: Build
         run: |
           git config --global url."https://github.com/".insteadOf git://github.com/
+          npm install --global npm
           npm install
           npm run build
         working-directory: contracts

--- a/.github/workflows/contracts-build.yml
+++ b/.github/workflows/contracts-build.yml
@@ -1,0 +1,42 @@
+name: Contracts
+
+on:
+  push:
+    branches: [ v1 ]
+  pull_request:
+    branches: [ v1 ]
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [14, 16]
+
+    steps:
+      - uses: actions/checkout@v3
+    
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          
+      - name: Build
+        run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
+          npm install
+          npm run build
+        working-directory: contracts
+
+      - name: Compile Solidity
+        run: npm run compileSol
+        working-directory: contracts
+
+      - name: Test
+        run: npx jest --runInBand
+        working-directory: contracts        

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -26,10 +26,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-          
+
       - name: Build
         run: |
           git config --global url."https://github.com/".insteadOf git://github.com/
+          npm install --global npm
           npm install
           npm run build
         working-directory: core

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -1,0 +1,39 @@
+name: Core
+
+on:
+  push:
+    branches: [ v1 ]
+  pull_request:
+    branches: [ v1 ]
+
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [14, 16]
+
+    steps:
+      - uses: actions/checkout@v3
+    
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          
+      - name: Build
+        run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
+          npm install
+          npm run build
+        working-directory: core
+
+      - name: Test
+        run: npm run test
+        working-directory: core

--- a/.github/workflows/crypto-build.yml
+++ b/.github/workflows/crypto-build.yml
@@ -1,0 +1,39 @@
+name: Crypto
+
+on:
+  push:
+    branches: [ v1 ]
+  pull_request:
+    branches: [ v1 ]
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [14, 16]
+
+    steps:
+      - uses: actions/checkout@v3
+    
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          
+      - name: Build
+        run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
+          npm install
+          npm install -D typescript
+          npm run build
+        working-directory: crypto
+
+      - name: Test
+        run: npm run test
+        working-directory: crypto

--- a/.github/workflows/crypto-build.yml
+++ b/.github/workflows/crypto-build.yml
@@ -25,10 +25,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-          
+
       - name: Build
         run: |
           git config --global url."https://github.com/".insteadOf git://github.com/
+          npm install --global npm
           npm install
           npm install -D typescript
           npm run build

--- a/.github/workflows/domainobjs-build.yml
+++ b/.github/workflows/domainobjs-build.yml
@@ -2,6 +2,7 @@ name: Domainobjs
 
 on:
   push:
+    branches: [ v1 ]
   pull_request:
     branches: [ v1 ]
 

--- a/.github/workflows/domainobjs-build.yml
+++ b/.github/workflows/domainobjs-build.yml
@@ -1,0 +1,38 @@
+name: Domainobjs
+
+on:
+  push:
+  pull_request:
+    branches: [ v1 ]
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [14, 16]
+
+    steps:
+      - uses: actions/checkout@v3
+    
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          
+      - name: Build
+        run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
+          npm install
+          npm run build
+        working-directory: domainobjs
+
+      - name: Test
+        run: |
+          npm run test
+        working-directory: domainobjs

--- a/.github/workflows/domainobjs-build.yml
+++ b/.github/workflows/domainobjs-build.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Build
         run: |
           git config --global url."https://github.com/".insteadOf git://github.com/
+          npm install --global npm
           npm install
           npm run build
         working-directory: domainobjs

--- a/README.md
+++ b/README.md
@@ -164,3 +164,7 @@ Run `docker build -t maci .` to build all stages.
 
 To run a specific build step `docker build --target circuits -t maci .`
 Note: a cached version of `builder` job must be on your system prior as it relies on existing artifacts
+
+### CI pipeline
+
+CI pipeline ensures that we have automated tests that constantly validate. For more information about pipeline workflows, see https://github.com/appliedzkp/maci/wiki/MACI-CI-pipeline.


### PR DESCRIPTION
This PR enables CI to validate sub-packages for every PR and commits to the `v1` branch.

When pull reqeust opened to the`v1` branch or code is pushed to the`v1` branch, it will trigger GitHub Actions. Then GitHub Actions runs tests for:

- Circuit
- Contracts
- Core
- Crypto
- Domainobjs